### PR TITLE
Fix pylint import errors

### DIFF
--- a/devcontainer-api/.devcontainer.json
+++ b/devcontainer-api/.devcontainer.json
@@ -13,8 +13,11 @@
 		},
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.linting.pylintPath": "/usr/local/share/pip-global/bin/pylint"
+		"python.defaultInterpreterPath": "/usr/bin/python3",
+		"python.linting.pylintPath": "/usr/local/share/pip-global/bin/pylint",
+		"python.analysis.extraPaths": [
+			"/home/vscode/.local/lib/python3.9/site-packages"
+		]
 	},
 	"features": {
 		"docker-from-docker": {


### PR DESCRIPTION
**NOTE:** Requires running `Remote-Containers: Rebuild container` in vscode command pallette to take effect (alternatively, you can destroy the salient docker containers)

These changes should eliminate most pylint missing import false positives.