### PR TITLE
Pass AWS creds to application environment

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,12 +26,13 @@ applications:
       NOTIFICATION_QUEUE_PREFIX: prototype_10x
       STATSD_HOST: localhost
 
-      INTERNAL_CLIENT_API_KEYS: '{"notify-admin":["((ADMIN_CLIENT_SECRET))"]}'
-
       # Credentials variables
+      INTERNAL_CLIENT_API_KEYS: '{"notify-admin":["((ADMIN_CLIENT_SECRET))"]}'
       ADMIN_CLIENT_SECRET: ((ADMIN_CLIENT_SECRET))
       DANGEROUS_SALT: ((DANGEROUS_SALT))
       SECRET_KEY: ((SECRET_KEY))
+      AWS_ACCESS_KEY_ID: ((AWS_ACCESS_KEY_ID))
+      AWS_SECRET_ACCESS_KEY: ((AWS_SECRET_ACCESS_KEY))
       AWS_REGION: us-west-2
       AWS_PINPOINT_REGION: us-west-2
       AWS_US_TOLL_FREE_NUMBER: +18446120782


### PR DESCRIPTION
Last bit of glue between passing the keys from github actions secrets into the deployed app.