### PR TITLE
Only run pip-audit on runtime dependencies in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: trailofbits/gh-action-pip-audit@v1.0.0
         with:
-          inputs: requirements.txt requirements_for_test.txt
+          inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237
 
   static-scan:

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - uses: trailofbits/gh-action-pip-audit@v1.0.0
         with:
-          inputs: requirements.txt requirements_for_test.txt
+          inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237
 
   static-scan:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ freeze-requirements: ## Pin all requirements including sub dependencies into req
 .PHONY: audit
 audit:
 	pip install --upgrade pip-audit
-	pip-audit -r requirements.txt -r requirements_for_test.txt -l --ignore-vuln PYSEC-2022-237
+	pip-audit -r requirements.txt -l --ignore-vuln PYSEC-2022-237
+	-pip-audit -r requirements_for_test.txt -l
 
 .PHONY: static-scan
 static-scan:


### PR DESCRIPTION
`make audit` will still run against test dependencies, but CI/CD should only care about things that are installed on the server.