### PR TITLE
Use setup action in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-    - name: Install container dependencies
-      run: |
-        sudo apt-get update \
-        && sudo apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev
-
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
@@ -48,11 +42,7 @@ jobs:
         TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
       run: terraform apply -auto-approve -input=false
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-
+    - uses: ./.github/actions/setup-project
     - name: Install application dependencies
       run: make bootstrap
 


### PR DESCRIPTION
This uses the existing project setup action in the deploy workflow, replacing redundant commands.

This popped up because we're now relying on `pipenv` to install dependencies, and need to pull that in.