### PR TITLE
Replace old notifications-api service prefix with notify-api

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -404,9 +404,9 @@ class Test(Development):
 class Production(Config):
     # buckets
     CSV_UPLOAD_BUCKET = cloud_config.s3_credentials(
-        f"notifications-api-csv-upload-bucket-{Config.NOTIFY_ENVIRONMENT}")
+        f"notify-api-csv-upload-bucket-{Config.NOTIFY_ENVIRONMENT}")
     CONTACT_LIST_BUCKET = cloud_config.s3_credentials(
-        f"notifications-api-contact-list-bucket-{Config.NOTIFY_ENVIRONMENT}")
+        f"notify-api-contact-list-bucket-{Config.NOTIFY_ENVIRONMENT}")
 
     FROM_NUMBER = 'US Notify'
     CRONITOR_ENABLED = True

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -29,11 +29,11 @@ def vcap_services():
         }],
         's3': [
             {
-                'name': 'notifications-api-csv-upload-bucket-test',
+                'name': 'notify-api-csv-upload-bucket-test',
                 'credentials': _bucket_credentials
             },
             {
-                'name': 'notifications-api-contact-list-bucket-test',
+                'name': 'notify-api-contact-list-bucket-test',
                 'credentials': {
                     'access_key_id': 'contact-access',
                     'bucket': 'contact-list-bucket',
@@ -69,7 +69,7 @@ def test_redis_url_falls_back_to_REDIS_URL():
 def test_s3_bucket_credentials(vcap_services):
     os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
 
-    assert CloudfoundryConfig().s3_credentials('notifications-api-csv-upload-bucket-test') == _bucket_credentials
+    assert CloudfoundryConfig().s3_credentials('notify-api-csv-upload-bucket-test') == _bucket_credentials
 
 
 def test_s3_bucket_credentials_falls_back_to_empty_creds():


### PR DESCRIPTION
Forgotten update from the cloud.gov migration.

#109