### PR TITLE
Enable deploying exact version of cg-egress-proxy

### DIFF
--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -7,6 +7,12 @@ inputs:
   app:
     description: application name to be proxied.
     required: true
+  proxy_repo:
+    description: git repo for cg-egress-proxy
+    default: https://github.com/rahearn/cg-egress-proxy.git
+  proxy_version:
+    description: git ref to be deployed
+    default: main
 runs:
   using: composite
   steps:
@@ -20,15 +26,17 @@ runs:
       shell: bash
       id: create-temp-dir
       run: echo "path=$(mktemp -d -t egress-XXXXXXXXXX --tmpdir=$RUNNER_TEMP)" >> $GITHUB_OUTPUT
-    - name: Clone egress-proxy
+    - name: Clone cg-egress-proxy
       shell: bash
-      run: git clone https://github.com/rahearn/cg-egress-proxy.git ${{ steps.create-temp-dir.outputs.path }}
+      run: git clone ${{ inputs.proxy_repo }} ${{ steps.create-temp-dir.outputs.path }}
+    - name: Switch to deploy ref
+      shell: bash
+      working_directory: ${{ steps.create-temp-dir.outputs.path }}
+      run: git checkout ${{ inputs.proxy_version }}
     - name: Copy config files
       shell: bash
       run: cp ./deploy-config/egress_proxy/${{ inputs.app }}.*.acl ${{ steps.create-temp-dir.outputs.path }}
     - name: Build and deploy proxy
       shell: bash
-      run: >
-        cd ${{ steps.create-temp-dir.outputs.path }};
-        make;
-        ./bin/cf-deployproxy -a ${{ inputs.app }} -p egress-proxy -e egress_proxy
+      working_directory: ${{ steps.create-temp-dir.outputs.path }}
+      run: make && ./bin/cf-deployproxy -a ${{ inputs.app }} -p egress-proxy -e egress_proxy

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -70,7 +70,10 @@ jobs:
       id: changed-egress-config
       uses: tj-actions/changed-files@v34
       with:
-        files: deploy-config/egress_proxy/notify-api-demo.*.acl
+        files: |
+          deploy-config/egress_proxy/notify-api-demo.*.acl
+          .github/actions/deploy-proxy/action.yml
+          .github/workflows/deploy-demo.yml
     - name: Deploy egress proxy
       if: steps.changed-egress-config.outputs.any_changed == 'true'
       uses: ./.github/actions/deploy-proxy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,10 @@ jobs:
       id: changed-egress-config
       uses: tj-actions/changed-files@v34
       with:
-        files: deploy-config/egress_proxy/notify-api-staging.*.acl
+        files: |
+          deploy-config/egress_proxy/notify-api-staging.*.acl
+          .github/actions/deploy-proxy/action.yml
+          .github/workflows/deploy.yml
     - name: Deploy egress proxy
       if: steps.changed-egress-config.outputs.any_changed == 'true'
       uses: ./.github/actions/deploy-proxy


### PR DESCRIPTION
Short-term effect is deploying the updates that close #117

Long-term we can be more specific with the version that we want to deploy, which will make it easier to test changes in staging without effecting demo/prod.