### PR TITLE
Run celery beat on cloud.gov

### DIFF
--- a/deploy-config/demo.yml
+++ b/deploy-config/demo.yml
@@ -3,5 +3,6 @@ web_instances: 1
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M
+scheduler_memory: 256M
 public_api_route: notify-api-demo.app.cloud.gov
 admin_base_url: https://notify-demo.app.cloud.gov

--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -3,5 +3,6 @@ web_instances: 2
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M
+scheduler_memory: 256M
 public_api_route: notify-api.app.cloud.gov
 admin_base_url: https://notify.app.cloud.gov

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -3,5 +3,6 @@ web_instances: 1
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M
+scheduler_memory: 256M
 public_api_route: notify-api-staging.app.cloud.gov
 admin_base_url: https://notify-staging.app.cloud.gov

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,10 @@ applications:
         instances: ((worker_instances))
         memory: ((worker_memory))
         command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4
+      - type: scheduler
+        instances: 1
+        memory: ((scheduler_memory))
+        command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery beat --loglevel=INFO
 
     env:
       NOTIFY_APP_NAME: api


### PR DESCRIPTION
Scheduled messages weren't being sent because celery beat wasn't running.

https://github.com/GSA/notifications-admin/issues/98