### PR TITLE
Official egress proxy

### DIFF
--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   proxy_repo:
     description: git repo for cg-egress-proxy
-    default: https://github.com/rahearn/cg-egress-proxy.git
+    default: https://github.com/GSA/cg-egress-proxy.git
   proxy_version:
     description: git ref to be deployed
     default: main

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: make run-flask
 worker: make run-celery
+scheduler: make run-celery-beat


### PR DESCRIPTION
Relevant PRs have been merged, so move our cg-egress-proxy deploy from my branch to the main repo.

closes #113 


Also sneaks a change it to include celery-beat in the list of processes to start up in development.