### PR TITLE
Exec web startup command

### DIFF
--- a/deploy-config/demo.yml
+++ b/deploy-config/demo.yml
@@ -1,5 +1,5 @@
 env: demo
-web_instances: 1
+web_instances: 2
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M

--- a/deploy-config/sandbox.yml
+++ b/deploy-config/sandbox.yml
@@ -3,6 +3,7 @@ web_instances: 1
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M
+scheduler_memory: 256M
 public_api_route: notify-api-sandbox.app.cloud.gov
 admin_base_url: https://notify-sandbox.app.cloud.gov
 ADMIN_CLIENT_SECRET: dev-notify-secret-key

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -1,5 +1,5 @@
 env: staging
-web_instances: 1
+web_instances: 2
 web_memory: 1G
 worker_instances: 1
 worker_memory: 512M

--- a/scripts/migrate_and_run_web.sh
+++ b/scripts/migrate_and_run_web.sh
@@ -4,4 +4,4 @@ if [[ $CF_INSTANCE_INDEX -eq 0 ]]; then
   flask db upgrade
 fi
 
-gunicorn -c ${HOME}/gunicorn_config.py application
+exec gunicorn -c ${HOME}/gunicorn_config.py application


### PR DESCRIPTION
Changes:

* allows for app to receive process signals from cloud foundry. [Doc source](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#start-commands:~:text=If%20you%20override,your%20own%20process.)
* Uses 2 web instances in every environment. The combination of 1 instance with `--strategy rolling` and `--no-wait` appears to be the cause of #128

closes #128 