### PR TITLE
Dependency updates

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,7 @@ boto3 = "==1.23.8"
 botocore = "==1.26.8"
 cachetools = "==5.1.0"
 celery = {version = "==5.2.7", extras = ["redis"]}
-certifi = "==2022.5.18.1"
+certifi = ">=2022.12.7"
 cffi = "==1.15.0"
 charset-normalizer = "==2.0.12"
 click = "==8.1.3"

--- a/Pipfile
+++ b/Pipfile
@@ -58,8 +58,8 @@ werkzeug = "~=2.1.1"
 # gds metrics packages
 prometheus-client = "==0.14.1"
 gds-metrics = {version = "==0.2.4", ref = "6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72", git = "https://github.com/alphagov/gds_metrics_python.git"}
-notifications-utils = {editable = true, ref = "3096f2937b5e3b59a2e7a4b4ffb05b7fa1ab72fa", git = "https://github.com/GSA/notifications-utils"}
 packaging = "==21.3"
+notifications-utils = {editable = true, branch = "main", git = "https://github.com/GSA/notifications-utils"}
 
 [dev-packages]
 flake8 = "==4.0.1"

--- a/Pipfile
+++ b/Pipfile
@@ -58,7 +58,8 @@ werkzeug = "~=2.1.1"
 # gds metrics packages
 prometheus-client = "==0.14.1"
 gds-metrics = {version = "==0.2.4", ref = "6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72", git = "https://github.com/alphagov/gds_metrics_python.git"}
-notifications-utils = {editable = true, ref = "37ae9753c050851453d072994fb03b1415601716", git = "https://github.com/GSA/notifications-utils"}
+notifications-utils = {editable = true, ref = "3096f2937b5e3b59a2e7a4b4ffb05b7fa1ab72fa", git = "https://github.com/GSA/notifications-utils"}
+packaging = "==21.3"
 
 [dev-packages]
 flake8 = "==4.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "445280351af84a8b83d60a5f18715d7f19b9b221e618ff5084b243824ecec4e5"
+            "sha256": "85a9f8510c648bb198793c2f0228a9f7f4b9579de89d70f7363a44d9eb997d32"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -157,11 +157,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
-                "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "index": "pypi",
-            "version": "==2022.5.18.1"
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [
@@ -1355,11 +1355,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
-                "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
             "index": "pypi",
-            "version": "==2022.5.18.1"
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85a9f8510c648bb198793c2f0228a9f7f4b9579de89d70f7363a44d9eb997d32"
+            "sha256": "64cec0ebf1afc8708dcbfee70bfa3881152b2c2487ace24b785e107821b95917"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -708,6 +708,7 @@
             "version": "==6.3.0"
         },
         "notifications-utils": {
+            "branch": "main",
             "editable": true,
             "git": "https://github.com/GSA/notifications-utils",
             "ref": "3096f2937b5e3b59a2e7a4b4ffb05b7fa1ab72fa"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d652255c8ca6f6cb96778b0159228628816a114f867510bd4ce13a9e9692b101"
+            "sha256": "445280351af84a8b83d60a5f18715d7f19b9b221e618ff5084b243824ecec4e5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -710,7 +710,7 @@
         "notifications-utils": {
             "editable": true,
             "git": "https://github.com/GSA/notifications-utils",
-            "ref": "37ae9753c050851453d072994fb03b1415601716"
+            "ref": "3096f2937b5e3b59a2e7a4b4ffb05b7fa1ab72fa"
         },
         "orderedset": {
             "hashes": [
@@ -731,15 +731,15 @@
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==21.3"
         },
         "phonenumbers": {
             "hashes": [
-                "sha256:07a95c2f178687fd1c3f722cf792b3d33e3a225ae71577e500c99b28544cd6d0",
-                "sha256:7cadfe900e833857500b7bafa3e5a7eddc3263eb66b66a767870b33e44665f92"
+                "sha256:0179f688d48c0e7e161eb7b9d86d587940af1f5174f97c1fdfd893c599c0d94a",
+                "sha256:884b26f775205261f4dc861371dce217c1661a4942fb3ec3624e290fb51869bf"
             ],
-            "version": "==8.13.1"
+            "version": "==8.13.2"
         },
         "prometheus-client": {
             "hashes": [
@@ -751,11 +751,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:535c29c31216c77302877d5120aef6c94ff573748a5b5ca5b1b1f76f5e700c73",
-                "sha256:ced598b222f6f4029c0800cefaa6a17373fb580cd093223003475ce32805c35b"
+                "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63",
+                "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.33"
+            "version": "==3.0.36"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -1003,10 +1003,10 @@
         },
         "redis": {
             "hashes": [
-                "sha256:30c07511627a4c5c4d970e060000772f323174f75e745a26938319817ead7a12",
-                "sha256:46652271dc7525cd5a9667e5b0ca983c848c75b2b8f7425403395bb8379dcf25"
+                "sha256:7b8c87d19c45d3f1271b124858d2a5c13160c4e74d4835e28273400fa34d5228",
+                "sha256:cae3ee5d1f57d8caf534cd8764edf3163c77e073bdd74b6f54a87ffafdc5e7d9"
             ],
-            "version": "==4.3.5"
+            "version": "==4.4.0"
         },
         "requests": {
             "hashes": [
@@ -1782,7 +1782,7 @@
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==21.3"
         },
         "pbr": {
@@ -1811,19 +1811,19 @@
         },
         "pip-audit": {
             "hashes": [
-                "sha256:a99f825ee431a89b89981c4e9e6eaacff5af3233783f2f5d79fe03306dc378ce",
-                "sha256:f87b37b6db5317a3f5ecebc202b5d4401958b5e4bd05b39d7b230bdc6f63c34b"
+                "sha256:40876d6ad6adf5ac64fba1ecef034db9804c35c2c18f7c22cb7b11b382c10df9",
+                "sha256:a45540ab0c5a9311315ca42c78fa8f72cf3598d5968a67d883d2d6194eda598c"
             ],
             "index": "pypi",
-            "version": "==2.4.7"
+            "version": "==2.4.8"
         },
         "pip-requirements-parser": {
             "hashes": [
-                "sha256:22fa213a987913385b2484d5698ecfa1d9cf4154978cdf929085548af55355b0",
-                "sha256:8c2a6f8e091ac2693824a5ef4e3b250226e34f74a20a91a87b9ab0714b47788f"
+                "sha256:5159b8a9485a5a0d0254a29c9bd8b8ce66db2eb9a1a0244c64dfce43f7f2ac90",
+                "sha256:aa664781e69f82ecefda542d5210aa5b0f6533be95aea39a5453943db09359ed"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==31.2.0"
+            "version": "==32.0.0"
         },
         "pluggy": {
             "hashes": [


### PR DESCRIPTION
Addresses pip-audit finding.

Freezes `packaging` because pipenv wasn't respecting the version requirement that `pip-audit` gave for that package.

Also updated other packages that still fit within Pipfile version requirements.

closes #138 