### PR TITLE
Gracefully handle decryption errors in past-7-days notification reports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,9 @@ import itertools
 import uuid
 
 from flask import current_app, url_for
+from notifications_utils.clients.encryption.encryption_client import (
+    EncryptionError,
+)
 from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.letter_timings import get_letter_timings
 from notifications_utils.postal_address import (
@@ -1512,7 +1515,10 @@ class Notification(db.Model):
     @property
     def personalisation(self):
         if self._personalisation:
-            return encryption.decrypt(self._personalisation)
+            try:
+                return encryption.decrypt(self._personalisation)
+            except EncryptionError:
+                current_app.logger.error("Error decrypting notification.personalisation, returning empty dict")
         return {}
 
     @personalisation.setter

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -160,6 +160,13 @@ def test_notification_personalisation_getter_always_returns_empty_dict(notify_ap
     assert noti.personalisation == {}
 
 
+def test_notification_personalisation_getter_returns_empty_dict_for_encryption_errors(notify_app):
+    noti = Notification()
+    # old _personalisation values were created with encryption.sign, which will trigger a decryption error
+    noti._personalisation = encryption.sign({"value": "PII"})
+    assert noti.personalisation == {}
+
+
 @pytest.mark.parametrize('input_value', [
     None,
     {}


### PR DESCRIPTION
Returning an empty-dictionary here causes the UI to act as if though personalization was redacted, which is a fine safe behavior.

Closes #148 

