### PR TITLE
Pip audit mitigation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Create requirements.txt
         run: pipenv requirements > requirements.txt
-      - uses: trailofbits/gh-action-pip-audit@v1.0.0
+      - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: ./.github/actions/setup-project
       - name: Create requirements.txt
         run: pipenv requirements > requirements.txt
-      - uses: trailofbits/gh-action-pip-audit@v1.0.0
+      - uses: pypa/gh-action-pip-audit@v1.0.4
         with:
           inputs: requirements.txt
           ignore-vulns: PYSEC-2022-237

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ freeze-requirements: ## Pin all requirements including sub dependencies into req
 audit:
 	pipenv requirements > requirements.txt
 	pipenv requirements --dev > requirements_for_test.txt
-	pipenv run pip-audit -r requirements.txt -l --ignore-vuln PYSEC-2022-237
-	-pipenv run pip-audit -r requirements_for_test.txt -l
+	pipenv run pip-audit -r requirements.txt --ignore-vuln PYSEC-2022-237
+	-pipenv run pip-audit -r requirements_for_test.txt
 
 .PHONY: static-scan
 static-scan:

--- a/docker-compose.devcontainer.yml
+++ b/docker-compose.devcontainer.yml
@@ -48,7 +48,6 @@ services:
       - redis
     links:
       - db
-    restart: always
   worker:
     container_name: worker
     image: dev-notification-api


### PR DESCRIPTION
Just need to update to most recent action to prevent a false finding.

Also removes the restart: always to prevent an unattached devcontainer from being spun up when Docker is launched

closes #159 