### PR TITLE
Add a system description entry to docs

### DIFF
--- a/docs/system-description.md
+++ b/docs/system-description.md
@@ -1,0 +1,38 @@
+US Notify
+=========
+
+System Description
+------------------
+
+US Notify is a service being developed by the TTS Benefits Studio to increase the availability of
+SMS and email notifications to Federal, State, and Local Benefits agencies.
+
+Agencies that sign up will be able to create and use personalized message templates for sending
+notifications to members of the public regarding their benefits. These could include reminders
+about upcoming enrollment deadlines and tasks, or information about upcoming appointments, events,
+or services.
+
+The templates are sent by the agency using one of two methods:
+
+* using the US Notify API to send a message to a given recipient with given personalization values
+* using the US Notify website to upload a CSV file of recipients and their personalization values, one row per message
+
+### Environment
+
+US Notify is comprised of two applications both running on cloud.gov:
+
+* Admin, a Flask website running on the python_buildpack which hosts agency user-facing UI
+* API, a Flask application running on the python_buildpack hosting the US Notify API
+
+US Notify utilizes several cloud.gov-provided services:
+
+* S3 buckets for temporary file storage
+* Elasticache (redis) for cacheing data and enqueueing background tasks
+* RDS (PostgreSQL) for system data storage
+
+US Notify also provides access to two AWS services via a supplemental service broker:
+
+* SNS for sending SMS messages
+* SES for sending email messages
+
+For further details of the system and how it connects to supporting services, see the [application boundary diagram](https://github.com/GSA/us-notify-compliance/blob/main/diagrams/rendered/apps/application.boundary.png)

--- a/docs/system-description.md
+++ b/docs/system-description.md
@@ -4,7 +4,7 @@ US Notify
 System Description
 ------------------
 
-US Notify is a service being developed by the TTS Benefits Studio to increase the availability of
+US Notify is a service being developed by the TTS Public Benefits Studio to increase the availability of
 SMS and email notifications to Federal, State, and Local Benefits agencies.
 
 Agencies that sign up will be able to create and use personalized message templates for sending

--- a/docs/system-description.md
+++ b/docs/system-description.md
@@ -30,9 +30,9 @@ US Notify utilizes several cloud.gov-provided services:
 * Elasticache (redis) for cacheing data and enqueueing background tasks
 * RDS (PostgreSQL) for system data storage
 
-US Notify also provides access to two AWS services via a supplemental service broker:
+US Notify also provisions and uses two AWS services via a [supplemental service broker](https://github.com/GSA/datagov-ssb):
 
-* SNS for sending SMS messages
-* SES for sending email messages
+* [SNS](https://aws.amazon.com/sns/) for sending SMS messages
+* [SES](https://aws.amazon.com/ses/) for sending email messages
 
 For further details of the system and how it connects to supporting services, see the [application boundary diagram](https://github.com/GSA/us-notify-compliance/blob/main/diagrams/rendered/apps/application.boundary.png)


### PR DESCRIPTION
This is going to be referenced in the FIPS 199 doc, SSPP, and probably others. The description goes after what I want to have authorized, which is a slightly larger scope than our initial pilot plans (includes emails and API access, for instance)

Work towards https://github.com/GSA/notifications-admin/issues/307

The section instructions state:

> Instruction: Insert a brief high-level description of the system, the system environment and the purpose of the system. The description should be consistent with the description found in the System Security Plan (SSP).