### PR TITLE
Provision sns via terraform in staging

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -67,3 +67,18 @@ module "ses_email" {
   email_domain        = "notify.sandbox.10x.gsa.gov"
   email_receipt_error = "notify-support@gsa.gov"
 }
+
+#########################################################################
+# Wait for SNS is out of sandbox and spending limit is increased
+# before activating this module
+#########################################################################
+# module "sns_sms" {
+#   source = "../shared/sns"
+
+#   cf_org_name         = local.cf_org_name
+#   cf_space_name       = local.cf_space_name
+#   name                = "${local.app_name}-sns-${local.env}"
+#   recursive_delete    = local.recursive_delete
+#   aws_region          = "us-gov-east-1"
+#   monthly_spend_limit = 25
+# }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -66,6 +66,21 @@ module "ses_email" {
   email_receipt_error = "notify-support@gsa.gov"
 }
 
+#########################################################################
+# Wait for SNS is out of sandbox and spending limit is increased
+# before activating this module
+#########################################################################
+# module "sns_sms" {
+#   source = "../shared/sns"
+
+#   cf_org_name         = local.cf_org_name
+#   cf_space_name       = local.cf_space_name
+#   name                = "${local.app_name}-sns-${local.env}"
+#   recursive_delete    = local.recursive_delete
+#   aws_region          = "us-gov-west-1"
+#   monthly_spend_limit = 1000
+# }
+
 ###########################################################################
 # The following lines need to be commented out for the initial `terraform apply`
 # It can be re-enabled after:

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -64,5 +64,21 @@ module "ses_email" {
   name                = "${local.app_name}-ses-${local.env}"
   recursive_delete    = local.recursive_delete
   aws_region          = "us-west-2"
+  email_domain        = "notify.sandbox.rcahearn.net"
   email_receipt_error = "notify-support@gsa.gov"
 }
+
+###############################################################
+# By default, sandbox uses the shared service instance from the
+# staging space
+###############################################################
+# module "sns_sms" {
+#   source = "../shared/sns"
+#
+#   cf_org_name         = local.cf_org_name
+#   cf_space_name       = local.cf_space_name
+#   name                = "${local.app_name}-sns-${local.env}"
+#   recursive_delete    = local.recursive_delete
+#   aws_region          = "us-west-2"
+#   monthly_spend_limit = 1
+# }

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -64,7 +64,6 @@ module "ses_email" {
   name                = "${local.app_name}-ses-${local.env}"
   recursive_delete    = local.recursive_delete
   aws_region          = "us-west-2"
-  email_domain        = "notify.sandbox.rcahearn.net"
   email_receipt_error = "notify-support@gsa.gov"
 }
 

--- a/terraform/shared/sns/main.tf
+++ b/terraform/shared/sns/main.tf
@@ -1,0 +1,27 @@
+###
+# Target space/org
+###
+
+data "cloudfoundry_space" "space" {
+  org_name = var.cf_org_name
+  name     = var.cf_space_name
+}
+
+###
+# SES instance
+###
+
+data "cloudfoundry_service" "sns" {
+  name = "ttsnotify-sms"
+}
+
+resource "cloudfoundry_service_instance" "sns" {
+  name             = var.name
+  space            = data.cloudfoundry_space.space.id
+  service_plan     = data.cloudfoundry_service.sns.service_plans["base"]
+  recursive_delete = var.recursive_delete
+  json_params = jsonencode({
+    region              = var.aws_region
+    monthly_spend_limit = var.monthly_spend_limit
+  })
+}

--- a/terraform/shared/sns/providers.tf
+++ b/terraform/shared/sns/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "~> 0.15"
+    }
+  }
+}

--- a/terraform/shared/sns/variables.tf
+++ b/terraform/shared/sns/variables.tf
@@ -1,0 +1,30 @@
+variable "cf_org_name" {
+  type        = string
+  description = "cloud.gov organization name"
+}
+
+variable "cf_space_name" {
+  type        = string
+  description = "cloud.gov space name (staging or prod)"
+}
+
+variable "name" {
+  type        = string
+  description = "name of the service instance"
+}
+
+variable "recursive_delete" {
+  type        = bool
+  description = "when true, deletes service bindings attached to the resource (not recommended for production)"
+  default     = false
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region the SNS settings are set in"
+}
+
+variable "monthly_spend_limit" {
+  type        = number
+  description = "SMS budget limit in USD. Support request must be made before raising above 1"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -66,3 +66,14 @@ module "ses_email" {
   aws_region          = "us-west-2"
   email_receipt_error = "notify-support@gsa.gov"
 }
+
+module "sns_sms" {
+  source = "../shared/sns"
+
+  cf_org_name         = local.cf_org_name
+  cf_space_name       = local.cf_space_name
+  name                = "${local.app_name}-sns-${local.env}"
+  recursive_delete    = local.recursive_delete
+  aws_region          = "us-west-2"
+  monthly_spend_limit = 25
+}


### PR DESCRIPTION
Adds commented-out versions for demo and prod that will be uncommented as various support requests are processed. Those tasks are tracked in TODO list in #38 

For spend limit: $1000 in production matches the cost estimate for the base year, demo & staging/sandbox/dev are each set to 25, but in practice we haven't gone above $2 so I'm amenable to lowering those if you think it's wise. The one reason not to is that updating that value in-place seems to not currently work, so changing it involves destroying the instance and re-creating it. It's a bit of a pain, so I set the values higher than currently needed now, but it also doesn't affect the things with long lead times like phone number provisioning so it's not a blocker.
