### PR TITLE
Brokerpak setup updates

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -21,7 +21,7 @@ def _remove_values_for_keys_if_present(dict, keys):
 
 def create_secret_code(length=6):
     random_number = randbelow(10 ** length)
-    return f"{random_number:06d}"
+    return "{:0{length}d}".format(random_number, length=length)
 
 
 def save_user_attribute(usr, update_dict=None):

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -68,17 +68,13 @@ module "ses_email" {
   email_receipt_error = "notify-support@gsa.gov"
 }
 
-#########################################################################
-# Wait for SNS is out of sandbox and spending limit is increased
-# before activating this module
-#########################################################################
-# module "sns_sms" {
-#   source = "../shared/sns"
+module "sns_sms" {
+  source = "../shared/sns"
 
-#   cf_org_name         = local.cf_org_name
-#   cf_space_name       = local.cf_space_name
-#   name                = "${local.app_name}-sns-${local.env}"
-#   recursive_delete    = local.recursive_delete
-#   aws_region          = "us-east-1"
-#   monthly_spend_limit = 25
-# }
+  cf_org_name         = local.cf_org_name
+  cf_space_name       = local.cf_space_name
+  name                = "${local.app_name}-sns-${local.env}"
+  recursive_delete    = local.recursive_delete
+  aws_region          = "us-east-1"
+  monthly_spend_limit = 25
+}

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -63,7 +63,7 @@ module "ses_email" {
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
   recursive_delete    = local.recursive_delete
-  aws_region          = "us-gov-west-1"
+  aws_region          = "us-west-2"
   email_domain        = "notify.sandbox.10x.gsa.gov"
   email_receipt_error = "notify-support@gsa.gov"
 }
@@ -79,6 +79,6 @@ module "ses_email" {
 #   cf_space_name       = local.cf_space_name
 #   name                = "${local.app_name}-sns-${local.env}"
 #   recursive_delete    = local.recursive_delete
-#   aws_region          = "us-gov-east-1"
+#   aws_region          = "us-east-1"
 #   monthly_spend_limit = 25
 # }

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -67,17 +67,13 @@ module "ses_email" {
   email_receipt_error = "notify-support@gsa.gov"
 }
 
-###############################################################
-# By default, sandbox uses the shared service instance from the
-# staging space
-###############################################################
-# module "sns_sms" {
-#   source = "../shared/sns"
-#
-#   cf_org_name         = local.cf_org_name
-#   cf_space_name       = local.cf_space_name
-#   name                = "${local.app_name}-sns-${local.env}"
-#   recursive_delete    = local.recursive_delete
-#   aws_region          = "us-west-2"
-#   monthly_spend_limit = 1
-# }
+module "sns_sms" {
+  source = "../shared/sns"
+
+  cf_org_name         = local.cf_org_name
+  cf_space_name       = local.cf_space_name
+  name                = "${local.app_name}-sns-${local.env}"
+  recursive_delete    = local.recursive_delete
+  aws_region          = "us-east-2"
+  monthly_spend_limit = 1
+}

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -185,7 +185,13 @@ def test_create_secret_code_different_subsequent_codes():
 
 def test_create_secret_code_returns_6_digits():
     code = create_secret_code()
-    assert len(str(code)) == 6
+    assert len(code) == 6
+
+
+def test_create_secret_code_can_customize_digits():
+    code_length = 10
+    code = create_secret_code(code_length)
+    assert len(code) == code_length
 
 
 @freeze_time('2018-07-07 12:00:00')


### PR DESCRIPTION
* Looks like we can't use us-gov-east-1 for SMS sending, so switching the entire demo setup over to the commercial AWS account.
* Also lays groundwork for sandbox to use its own SMS service, since sharing isn't supported in space-scoped brokers.

Work in support of #180 and #38