### PR TITLE
Add a mail-from subdomain to staging and prod ses

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -63,6 +63,7 @@ module "ses_email" {
   recursive_delete    = local.recursive_delete
   aws_region          = "us-gov-west-1"
   email_domain        = "notify.gov"
+  mail_from_subdomain = "mail"
   email_receipt_error = "notify-support@gsa.gov"
 }
 

--- a/terraform/shared/ses/main.tf
+++ b/terraform/shared/ses/main.tf
@@ -23,6 +23,7 @@ resource "cloudfoundry_service_instance" "ses" {
   json_params = jsonencode({
     region                        = var.aws_region
     domain                        = var.email_domain
+    mail_from_subdomain           = var.mail_from_subdomain
     email_receipt_error           = var.email_receipt_error
     enable_feedback_notifications = true
   })

--- a/terraform/shared/ses/variables.tf
+++ b/terraform/shared/ses/variables.tf
@@ -34,3 +34,9 @@ variable "email_receipt_error" {
   type        = string
   description = "email address to list in SPF records for errors to be sent to"
 }
+
+variable "mail_from_subdomain" {
+  type        = string
+  description = "Subdomain of email_domain to set as the mail-from header"
+  default     = ""
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -64,6 +64,7 @@ module "ses_email" {
   name                = "${local.app_name}-ses-${local.env}"
   recursive_delete    = local.recursive_delete
   aws_region          = "us-west-2"
+  mail_from_subdomain = "mail"
   email_receipt_error = "notify-support@gsa.gov"
 }
 


### PR DESCRIPTION
Adds a custom mail-from to allow mail to appear to be delivered from `mail.<insert domain that we actually get>.gov` rather than `amazonses.com`

There's a chance the apply to staging won't work if the broker doesn't accept this change. If that happens, it is not a problem to manually delete the staging ses service instance using `terraform destroy -target=module.ses_email` and re-run the deploy action. That won't be a problem for prod because nothing has been setup yet.

Closes https://github.com/GSA/notifications-admin/issues/397