### PR TITLE
Add infrastructure drift detector

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,0 +1,66 @@
+name: Verify Infrastructure
+
+on:
+  schedule:
+    # cron format: 'minute hour dayofmonth month dayofweek'
+    # this will run at noon UTC every day (7am EST / 8am EDT)
+    - cron: '0 12 * * *'
+
+jobs:
+  check_staging_drift:
+    runs-on: ubuntu-latest
+    name: Check for drift of staging terraform configuration
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check for drift
+        uses: dflook/terraform-check@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+          TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+          TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+        with:
+          path: terraform/staging
+
+  check_demo_drift:
+    runs-on: ubuntu-latest
+    name: Check for drift of demo terraform configuration
+    environment: demo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: 'production'
+
+      - name: Check for drift
+        uses: dflook/terraform-check@v1
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+          TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+          TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+        with:
+          path: terraform/demo
+
+  # check_prod_drift:
+  #   runs-on: ubuntu-latest
+  #   name: Check for drift of production terraform configuration
+  #   environment: production
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: 'production'
+
+  #     - name: Check for drift
+  #       uses: dflook/terraform-check@v1
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+  #         TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+  #         TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+  #       with:
+  #         path: terraform/production

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,7 @@ Within GitHub Actions, several scans take place every day to ensure security and
 
 #### [drift.yml](../.github/workflows/drift.yml)
 
-`drift.yml` checks the deployed infrastructure against the expected configuration. A failure here is a flag to check audit logs for unexpected access and/or behavior and potentially destroy and re-deploy the infrastructure and application.
+`drift.yml` checks the deployed infrastructure against the expected configuration. A failure here is a flag to check audit logs for unexpected access and/or behavior and potentially destroy and re-deploy the application. Destruction and redeployment of all underlying infrastructure is an extreme remediation, and should only be attempted after ensuring that a good database backup is in hand.
 
 ## Manual testing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,19 @@ We're using GitHub Actions. See [/.github](../.github/) for the configuration.
 
 In addition to commit-triggered scans, the `daily_checks.yml` workflow runs the relevant dependency audits, static scan, and/or dynamic scans at 10am UTC each day. Developers will be notified of failures in daily scans by GitHub notifications.
 
+### Nightly Scans
+
+Within GitHub Actions, several scans take place every day to ensure security and compliance.
+
+
+#### [daily-checks.yml](../.github/workflows/daily_checks.yml)
+
+`daily-checks.yml` runs `pip-audit`, `bandit`, and `owasp` scans to ensure that any newly found vulnerabilities do not impact notify. Failures should be addressed quickly as they will also block the next attempted deploy.
+
+#### [drift.yml](../.github/workflows/drift.yml)
+
+`drift.yml` checks the deployed infrastructure against the expected configuration. A failure here is a flag to check audit logs for unexpected access and/or behavior and potentially destroy and re-deploy the infrastructure and application.
+
 ## Manual testing
 
 If you're checking out the system locally, you may want to create a user quickly.


### PR DESCRIPTION
This workflow will run each morning to ensure that terraform knows about all infrastructure changes.

In support of control CM-6.1

Production check should be uncommented once it exists.