### PR TITLE
Add workflow to restage apps

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -1,0 +1,36 @@
+---
+name: Restage apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment needs to be restaged"
+        required: true
+        default: staging
+        type: environment
+
+jobs:
+  restage_apps:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        app: ["api", "admin"]
+    steps:
+      - name: Restage ${{matrix.app}}
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
+          cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_space: notify-${{ inputs.environment }}
+          full_command: "cf restage --strategy rolling notify-${{matrix.app}}-${{inputs.environment}}"
+      - name: Restage ${{matrix.app}} egress
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
+          cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_space: notify-${{ inputs.environment }}-egress
+          full_command: "cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -1,6 +1,6 @@
 locals {
   cf_org_name      = "gsa-tts-benefits-studio-prototyping"
-  cf_space_name    = "notify-prod"
+  cf_space_name    = "notify-production"
   env              = "production"
   app_name         = "notify-api"
   recursive_delete = false


### PR DESCRIPTION
Changes

* add a manually-run workflow to restage apps in `notify-<env>` and `notify-<env>-egress`
* Switch `notify-prod` space to `notify-production` so that the space and environment names are consistent

There will be a matching PR on usnotify-ssb to restage the ssb apps and update the space name, and one on admin for the space name. Documentation for using this workflow has already been added as a task on #192 

Work towards #203 