### PR TITLE
Allow demo to send SMS via us-east-1 region through proxy

### DIFF
--- a/deploy-config/egress_proxy/notify-api-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-demo.allow.acl
@@ -1,4 +1,4 @@
 email.us-west-2.amazonaws.com
-sns.us-west-2.amazonaws.com
+sns.us-east-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-demo.apps.internal


### PR DESCRIPTION
Forgot to update the region in the proxy config when we moved out of tts-sandbox.

Demo sends email via us-west-2 because we can have multiple environments there, but SNS uses per-region settings so all of our environments have their own region.

Regions in the `notify-api-<env>.allow.acl` URLs should match what is specified in `terraform/<env>/main.tf`