### PR TITLE
Run terraform on deploy when shared modules change

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -20,7 +20,10 @@ jobs:
       id: changed-terraform-files
       uses: tj-actions/changed-files@v34
       with:
-        files: terraform/demo
+        files: |
+          terraform/demo
+          terraform/shared
+          .github/workflows/deploy-demo.yml
     - name: Terraform init
       if: steps.changed-terraform-files.outputs.any_changed == 'true'
       working-directory: terraform/demo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,10 @@ jobs:
       id: changed-terraform-files
       uses: tj-actions/changed-files@v34
       with:
-        files: terraform/staging
+        files: |
+          terraform/staging
+          terraform/shared
+          .github/workflows/deploy.yml
     - name: Terraform init
       if: steps.changed-terraform-files.outputs.any_changed == 'true'
       working-directory: terraform/staging


### PR DESCRIPTION
closes #208 

This will need to be deployed to demo today to prevent the drift detector action from continuing to fail.