### PR TITLE
Keep development SES & SNS keys open

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -42,10 +42,10 @@ for experimenting with infrastructure changes without going through the full CI/
 Rules for use:
 
 1. Ensure that no other developer is using the environment, as there is nothing stopping changes from overwriting each other.
-1. Clean up when you are done: 
+1. Clean up when you are done:
     - `terraform destroy` from within the `terraform/sandbox` directory will take care of the provisioned services
     - Delete the apps and routes shown in `cf apps` by running `cf delete APP_NAME -r`
-    - Delete the space deployers still shown in `cf services` by running `terraform/destroy_service_account.sh -s notify-sandbox -u <space-deployer>`
+    - Delete the space deployer you created by following the instructions within `terraform/sandbox/secrets.auto.tfvars`
 
 ### Deploying to the sandbox
 
@@ -58,7 +58,8 @@ Rules for use:
     $ terraform apply
     ```
 1. start a pipenv shell as a shortcut to load `.env` file variables: `$ pipenv shell`
+1. Output requirements.txt file: `pipenv requirements > requirements.txt`
 1. Deploy the application:
   ```
-  cf push --vars-file deploy-config/sandbox.yml
+  cf push --vars-file deploy-config/sandbox.yml --var NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY
   ```

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,17 +1,13 @@
 locals {
-  cf_api_url      = "https://api.fr.cloud.gov"
   s3_service_name = "notify-terraform-state"
 }
 
 module "s3" {
-  source = "github.com/18f/terraform-cloudgov//s3"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.3.0"
 
-  cf_api_url      = local.cf_api_url
-  cf_user         = var.cf_user
-  cf_password     = var.cf_password
-  cf_org_name     = "gsa-tts-benefits-studio-prototyping"
-  cf_space_name   = "notify-management"
-  s3_service_name = local.s3_service_name
+  cf_org_name   = "gsa-tts-benefits-studio-prototyping"
+  cf_space_name = "notify-management"
+  name          = local.s3_service_name
 }
 
 resource "cloudfoundry_service_key" "bucket_creds" {

--- a/terraform/bootstrap/providers.tf
+++ b/terraform/bootstrap/providers.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "cloudfoundry" {
-  api_url      = local.cf_api_url
+  api_url      = "https://api.fr.cloud.gov"
   user         = var.cf_user
   password     = var.cf_password
   app_logs_max = 30

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -43,6 +43,9 @@ data "cloudfoundry_service_instance" "ses_email" {
 resource "cloudfoundry_service_key" "ses_key" {
   name             = local.key_name
   service_instance = data.cloudfoundry_service_instance.ses_email.id
+  params_json = jsonencode({
+    source_ips = [var.source_ip]
+  })
 }
 
 data "cloudfoundry_service_instance" "sns_sms" {
@@ -52,6 +55,9 @@ data "cloudfoundry_service_instance" "sns_sms" {
 resource "cloudfoundry_service_key" "sns_key" {
   name             = local.key_name
   service_instance = data.cloudfoundry_service_instance.sns_sms.id
+  params_json = jsonencode({
+    source_ips = [var.source_ip]
+  })
 }
 
 locals {

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -3,3 +3,7 @@ variable "cf_password" {
 }
 variable "cf_user" {}
 variable "username" {}
+variable "source_ip" {
+  type    = string
+  default = "0.0.0.0/0"
+}


### PR DESCRIPTION
I have a ticket to service desk asking for an authoritative answer to what the VPN & Zscaler egress IPs are. Once we have that answer we can lock down the development service keys more appropriately. This change keeps the prior behavior that existed before the SSB updates.