### PR TITLE
Add reset state script

### DIFF
--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.50.5"
+      version = "0.50.7"
     }
   }
 }


### PR DESCRIPTION
Adds a reset script to `terraform/development`

This script:

1) imports the s3 bucket into the terraform state
2) deletes the three service keys
3) runs `./run.sh` to recreate the service keys and output the creds to `.env`

I think ideally we'd use `terraform import` for the service keys as well, but I consistently ran into [errors with the cloud foundry provider not being able to import the keys](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1681740568771519)

#235 