### PR TITLE
Add coverage report to API

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,8 +46,10 @@ jobs:
       run: pipenv run flake8 .
     - name: Check imports alphabetized
       run: pipenv run isort --check-only ./app ./tests
-    - name: Run tests
-      run: pipenv run pytest -n4 --maxfail=10
+    - name: Run tests with coverage
+      run: pipenv run coverage run --omit=*/notifications_utils/* -m pytest -n4 --maxfail=10
+    - name: Check coverage threshold
+      run: pipenv run coverage report --fail-under=50
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Check imports alphabetized
       run: pipenv run isort --check-only ./app ./tests
     - name: Run tests with coverage
-      run: pipenv run coverage run --omit=*/notifications_utils/* -m pytest -n4 --maxfail=10
+      run: pipenv run coverage run -m pytest -n4 --maxfail=10
     - name: Check coverage threshold
       run: pipenv run coverage report --fail-under=50
       env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,11 +47,11 @@ jobs:
     - name: Check imports alphabetized
       run: pipenv run isort --check-only ./app ./tests
     - name: Run tests with coverage
-      run: pipenv run coverage run -m pytest -n4 --maxfail=10
-    - name: Check coverage threshold
-      run: pipenv run coverage report --fail-under=50
+      run: pipenv run coverage run --omit=*/notifications_utils/* -m pytest -n4 --maxfail=10
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+    - name: Check coverage threshold
+      run: pipenv run coverage report --fail-under=50
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
     - name: Check coverage threshold
-      run: pipenv run coverage report --fail-under=50
+      run: pipenv run coverage report --fail-under=60
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
     - name: Check coverage threshold
-      run: pipenv run coverage report --fail-under=60
+      run: pipenv run coverage report --fail-under=50
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage_cache
 .coverage.*
 .cache
 .pytest_cache
@@ -76,6 +77,7 @@ environment.sh
 varsfile
 
 celerybeat-schedule
+celerybeat-schedule.db
 
 # CloudFoundry
 .cf

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,12 @@ generate-version-file: ## Generates the app version file
 
 .PHONY: test
 test: export NEW_RELIC_ENVIRONMENT=test
-test: ## Run tests
+test: ## Run tests and create coverage report
 	pipenv run flake8 .
 	pipenv run isort --check-only ./app ./tests
-	pipenv run pytest -n4 --maxfail=10
+	pipenv run coverage run -m pytest -n4 --maxfail=10
+	pipenv run coverage report
+	pipenv run coverage html -d .coverage_cache
 
 .PHONY: freeze-requirements
 freeze-requirements: ## Pin all requirements including sub dependencies into requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ test: export NEW_RELIC_ENVIRONMENT=test
 test: ## Run tests and create coverage report
 	pipenv run flake8 .
 	pipenv run isort --check-only ./app ./tests
-	pipenv run coverage run -m pytest -n4 --maxfail=10
-	pipenv run coverage report
+	pipenv run coverage run --omit=*/notifications_utils/* -m pytest -n4 --maxfail=10
+	pipenv run coverage report --fail-under=50
 	pipenv run coverage html -d .coverage_cache
 
 .PHONY: freeze-requirements


### PR DESCRIPTION
Initial steps to creating coverage in API repo.

Using `coverage.py` as the coverage tool. Widely used and easy to implement. Commands have been added to the Makefile. When running `make test` the output should appear as below. The coverage threshold has been set to 50% for now to avoid every PR from failing. As we fix tests/work on the code we can raise the threshold up to 90% where we eventually want to be. The threshold is the same for Github Actions.

<img width="440" alt="Screen Shot 2023-04-19 at 8 51 04 AM" src="https://user-images.githubusercontent.com/90117200/233114294-a037008e-c505-469d-ab27-d4094413004d.png">


When running the coverage report, open the `.coverage_cache` and select `index.html` then open with browser.

