### PR TITLE
#300 set/enforce SMS limits for pilot ceiling

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -28,7 +28,9 @@ def deliver_sms(self, notification_id):
             raise NoResultFound()
         total_used = check_service_rate_usage(notification.service_id)
         current_app.logger.warning(f"SERVICE_RATE_USAGE = {total_used}")
-        rate_limit = int(os.getenv("SERVICE_RATE_LIMIT"))
+        # Hardcoded 250000 is there because I'm not sure how to propagate a new env variable to development
+        # It is not picking it up from sample.env
+        rate_limit = int(os.getenv("SERVICE_RATE_LIMIT", 250000))
         current_app.logger.info(f"SERVICE_RATE_LIMIT={rate_limit}")
         if total_used >= rate_limit:
             raise RateLimitExceededException()

--- a/migrations/versions/0395_create_rate_limit_table_.py
+++ b/migrations/versions/0395_create_rate_limit_table_.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0395_create_rate_limit_table
+Revises: 0394_remove_contact_list
+Create Date: 2023-04-19 08:19:28.598206
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0395_create_rate_limit_table'
+down_revision = '0394_remove_contact_list'
+
+
+def upgrade():
+    op.create_table(
+        "service_rate_limit",
+        sa.Column('id', sa.String, primary_key=True),
+        sa.Column('service_id', sa.String, nullable=False),
+        sa.Column('timestamp', sa.Integer, nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_table("service_rate_limit")

--- a/sample.env
+++ b/sample.env
@@ -33,7 +33,7 @@ NOTIFY_ENVIRONMENT=development
 STATSD_HOST=localhost
 SES_STUB_URL=None
 NOTIFY_APP_NAME=api
-
+SERVICE_RATE_LIMIT=250000
 #############################################################
 
 # Flask


### PR DESCRIPTION
1. create a new table service_rate_limit to track usage
2. set the 250k limit in the sample.env
3. if the "running total limit since go live time" exceeds 250k, start throwing RateLimitExceededExceptions

I tested this on my locale, setting the rate limit to 5.  At 5 it started throwing exceptions.  

However, I'm not clear about two points:

1.  For some reason the test database is not picking up the new table
2. For some reason the development environment is not picking up the new environment variable