### PR TITLE
Deploy bundled proxy instead of building it each time (API)

### DIFF
--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Copy config files
       shell: bash
       run: cp ./deploy-config/egress_proxy/${{ inputs.app }}.*.acl ${{ steps.create-temp-dir.outputs.path }}
-    - name: Build and deploy proxy
+    - name: Deploy proxy
       shell: bash
       working-directory: ${{ steps.create-temp-dir.outputs.path }}
-      run: make && ./bin/cf-deployproxy -a ${{ inputs.app }} -p egress-proxy -e egress_proxy
+      run: ./bin/cf-deployproxy -a ${{ inputs.app }} -p egress-proxy -e egress_proxy


### PR DESCRIPTION
Proxy binary is included in the repo since https://github.com/GSA-TTS/cg-egress-proxy/pull/20 and https://github.com/GSA-TTS/cg-egress-proxy/pull/23