### PR TITLE
notify-301 allow services to move to production

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from flask import current_app
 from dateutil.parser import parse
 from flask_marshmallow.fields import fields
 from marshmallow import (

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from uuid import UUID
 
+from flask import current_app
 from dateutil.parser import parse
 from flask_marshmallow.fields import fields
 from marshmallow import (
@@ -274,7 +275,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     def validate_permissions(self, value):
         permissions = [v.permission for v in value]
         for p in permissions:
-            if p not in models.SERVICE_PERMISSION_TYPES:
+            if p not in models.SERVICE_PERMISSION_TYPES and p != "international_letters":
                 raise ValidationError("Invalid Service Permission: '{}'".format(p))
 
         if len(set(permissions)) != len(permissions):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -274,7 +274,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     def validate_permissions(self, value):
         permissions = [v.permission for v in value]
         for p in permissions:
-            if p not in models.SERVICE_PERMISSION_TYPES and p != "international_letters":
+            if p not in models.SERVICE_PERMISSION_TYPES:
                 raise ValidationError("Invalid Service Permission: '{}'".format(p))
 
         if len(set(permissions)) != len(permissions):

--- a/migrations/versions/0395_remove_intl_letters_perm.py
+++ b/migrations/versions/0395_remove_intl_letters_perm.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0395_remove_international_letters_permission
+Revises: 0394_remove_contact_list
+Create Date: 2023-05-23 10:03:10.485368
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0395_remove_intl_letters_perm'
+down_revision = '0394_remove_contact_list'
+
+
+def upgrade():
+    sql = """
+        DELETE
+        FROM service_permissions
+        WHERE permission = 'international_letters'
+    """
+
+    conn = op.get_bind()
+    conn.execute(sql)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
The only error I was seeing was that "international_letters" appeared in the total set of permissions, but did not appear in models.SERVICE_PERMISSION_TYPES.  Hence, it was being rejected as an invalid permission.  I excluded it and now I can toggle Live to On/Off locally.