### PR TITLE
Add steps for exporting test results

### DIFF
--- a/docs/run-book.md
+++ b/docs/run-book.md
@@ -123,6 +123,18 @@ U.S. Notify DNS records are maintained within [the 18f/dns repository](https://g
 1. Request a PR review from the 18F/tts-tech-portfolio team
 1. Once the PR is approved and merged, verify that the apply step happened correctly within [CircleCI](https://app.circleci.com/pipelines/github/18F/dns)
 
+## Exporting test results for compliance monitoring
+
+- Head to https://github.com/GSA/notifications-api/actions/workflows/daily_checks.yml
+- Open the most recent scan (it should be today's)
+- Scroll down to "Artifacts", click to download the .zip of OWASP ZAP results
+- Rename to `api_zap_scan_DATE.zip` and add it to 🔒 https://drive.google.com/drive/folders/1CFO-hFf9UjzU2JsZxdZeGRfw-a47u7e1
+- Click any of the jobs to open the logs
+- In top right of logs, click the gear icon
+- Select "Download log archive" to download a .zip of the test output for all jobs
+- Rename to `api_static_scan_DATE.zip` and add it to 🔒 https://drive.google.com/drive/folders/1dSe9H7Ag_hLfi5hmQDB2ktWaDwWSf4_R
+- Repeat for https://github.com/GSA/notifications-admin/actions/workflows/daily_checks.yml
+
 
 ## <a name="gotcha"></a> Known Gotchas
 


### PR DESCRIPTION
This add the process for downloading our compliance-related test results and uploading them to the place where we store them.