### PR TITLE
notify-api-317 fix the scrubbing of pii for successful notifications

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -11,7 +11,7 @@ from app.clients.sms import SmsClientResponseException
 from app.config import QueueNames
 from app.dao import notifications_dao
 from app.dao.notifications_dao import (
-    sanitize_notifications_by_id,
+    sanitize_successful_notification_by_id,
     update_notification_status_by_id,
 )
 from app.delivery import send_to_providers
@@ -37,14 +37,16 @@ def check_sms_delivery_receipt(self, message_id, notification_id, sent_at):
     status, provider_response = aws_cloudwatch_client.check_sms(message_id, notification_id, sent_at)
     if status == 'success':
         status = NOTIFICATION_DELIVERED
-    else:
+    elif status == 'failure':
         status = NOTIFICATION_FAILED
-    update_notification_status_by_id(notification_id, status, provider_response=provider_response)
-    current_app.logger.info(f"Updated notification {notification_id} with response '{provider_response}'")
+    # if status is not success or failure the client raised an exception and this method will retry
 
     if status == NOTIFICATION_DELIVERED:
-        sanitize_notifications_by_id(notification_id)
+        sanitize_successful_notification_by_id(notification_id)
         current_app.logger.info(f"Sanitized notification {notification_id} that was successfully delivered")
+    else:
+        update_notification_status_by_id(notification_id, status, provider_response=provider_response)
+        current_app.logger.info(f"Updated notification {notification_id} with response '{provider_response}'")
 
 
 @notify_celery.task(bind=True, name="deliver_sms", max_retries=48, default_retry_delay=300)

--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -84,6 +84,6 @@ class AwsCloudwatchClient(Client):
         if all_failed_events and len(all_failed_events) > 0:
             event = all_failed_events[0]
             message = json.loads(event['message'])
-            return "fail", message['delivery']['providerResponse']
+            return "failure", message['delivery']['providerResponse']
 
         raise Exception(f'No event found for message_id {message_id} notification_id {notification_id}')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -271,7 +271,6 @@ def _filter_query(query, filter_dict=None):
     return query
 
 
-@autocommit
 def sanitize_successful_notification_by_id(
     notification_id
 ):
@@ -283,6 +282,7 @@ def sanitize_successful_notification_by_id(
         {'to': phone_prefix, 'normalised_to': phone_prefix, 'status': 'delivered'},
         synchronize_session=False
     )
+    db.session.commit()
 
 
 @autocommit

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -272,7 +272,7 @@ def _filter_query(query, filter_dict=None):
 
 
 @autocommit
-def sanitize_notifications_by_id(
+def sanitize_successful_notification_by_id(
     notification_id
 ):
     # TODO what to do for international?
@@ -280,11 +280,9 @@ def sanitize_notifications_by_id(
     Notification.query.filter(
         Notification.id.in_([notification_id]),
     ).update(
-        {'to': phone_prefix, 'normalised_to': phone_prefix},
+        {'to': phone_prefix, 'normalised_to': phone_prefix, 'status': 'delivered'},
         synchronize_session=False
     )
-
-    db.session.commit()
 
 
 @autocommit

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -121,8 +121,6 @@ def persist_notification(
         updated_at=updated_at
     )
 
-    current_app.logger.info('Persisting notification with to address: {}'.format(notification.to))
-
     if notification_type == SMS_TYPE:
         formatted_recipient = validate_and_format_phone_number(recipient, international=True)
         recipient_info = get_international_phone_info(formatted_recipient)
@@ -133,7 +131,6 @@ def persist_notification(
     elif notification_type == EMAIL_TYPE:
         current_app.logger.info('Persisting notification with type: {}'.format(EMAIL_TYPE))
         notification.normalised_to = format_email_address(notification.to)
-        current_app.logger.info('Persisting notification to formatted email: {}'.format(notification.normalised_to))
 
     # if simulated create a Notification model to return but do not persist the Notification to the dB
     if not simulated:


### PR DESCRIPTION
When a notification is declared successful, the original code did:

1. mark the notification as 'delivered'
2. remove the phone number from the to and normalised_to fields

in two separate queries.

While this worked fine locally, on staging it appears like step #2 is failing, leading to the result that users can see successful notifications in their reports with PII, which is not desirable.

Change the code so that the same query that marks the notification as 'delivered' also removes the phone numbers, and add a unit test to show it works.   This currently cannot be reproduced locally, so will need to be tested on staging.