### PR TITLE
try using vanilla sql for problematic query

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -271,17 +271,28 @@ def _filter_query(query, filter_dict=None):
     return query
 
 
+@autocommit
 def sanitize_successful_notification_by_id(
     notification_id
 ):
     # TODO what to do for international?
-    phone_prefix = '1'
-    Notification.query.filter(
-        Notification.id.in_([notification_id]),
-    ).update(
-        {'to': phone_prefix, 'normalised_to': phone_prefix, 'status': 'delivered'}
-    )
-    db.session.commit()
+    # phone_prefix = '1'
+    # Notification.query.filter(
+    #     Notification.id.in_([notification_id]),
+    # ).update(
+    #     {'to': phone_prefix, 'normalised_to': phone_prefix, 'status': 'delivered'}
+    # )
+    # db.session.commit()
+
+    update_query = """
+    update notifications set notification_status='delivered', "to"='1', normalised_to='1'
+    where id=:notification_id
+    """
+    input_params = {
+        "notification_id": notification_id
+    }
+
+    db.session.execute(update_query, input_params)
 
 
 @autocommit


### PR DESCRIPTION
The method sanitize_succcessful_notification_by_id has been failing on staging, even though it works locally.  The error relates to connecting to the db and the suspicion is the problem has something to do with esoteric aspects of the SQLAlchemy query language.   Try to work around this by writing the query in ordinary sql.