### PR TITLE
Add logs AWS endpoint to staging proxy allow list

### DIFF
--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -1,3 +1,4 @@
+logs.us-west-2.amazonaws.com
 monitoring.us-west-2.amazonaws.com
 email.us-west-2.amazonaws.com
 sns.us-west-2.amazonaws.com


### PR DESCRIPTION
Helps address an issue with #317 

This changeset adds another endpoint to the staging egress proxy to enable access to AWS CloudWatch logs.

NOTE:  We will have to probably do this for production as well.

## Security Considerations

- This opens another specific endpoint for an AWS service with our egress proxy.  We need to do this in order to retrieve information that is necessary for the application to function properly.