### PR TITLE
notify-api-340 remove daily limit

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -30,11 +30,9 @@ from app.models import (
     SMS_TYPE,
 )
 from app.notifications.process_notifications import persist_notification
-from app.notifications.validators import check_service_over_daily_message_limit
 from app.serialised_models import SerialisedService, SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
 from app.utils import DATETIME_FORMAT
-from app.v2.errors import TooManyRequestsError
 
 
 @notify_celery.task(name="process-job")
@@ -57,9 +55,6 @@ def process_job(job_id, sender_id=None):
         dao_update_job(job)
         current_app.logger.warning(
             "Job {} has been cancelled, service {} is inactive".format(job_id, service.id))
-        return
-
-    if __sending_limits_for_job_exceeded(service, job, job_id):
         return
 
     recipient_csv, template, sender_id = get_recipient_csv_and_template_and_sender_id(job)
@@ -132,24 +127,6 @@ def process_row(row, template, job, service, sender_id=None):
         queue=QueueNames.DATABASE if not service.research_mode else QueueNames.RESEARCH_MODE
     )
     return notification_id
-
-
-def __sending_limits_for_job_exceeded(service, job, job_id):
-    try:
-        total_sent = check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-        if total_sent + job.notification_count > service.message_limit:
-            raise TooManyRequestsError(service.message_limit)
-        else:
-            return False
-    except TooManyRequestsError:
-        job.job_status = 'sending limits exceeded'
-        job.processing_finished = datetime.utcnow()
-        dao_update_job(job)
-        current_app.logger.info(
-            "Job {} size {} error. Sending limits {} exceeded".format(
-                job_id, job.notification_count, service.message_limit)
-        )
-        return True
 
 
 @notify_celery.task(bind=True, name="save-sms", max_retries=5, default_retry_delay=300)

--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,6 @@ import json
 from datetime import timedelta
 from os import getenv, path
 
-import notifications_utils
 from celery.schedules import crontab
 from kombu import Exchange, Queue
 
@@ -273,8 +272,6 @@ class Config(object):
     SIMULATED_SMS_NUMBERS = ('+12028675000', '+12028675111', '+12028675222')
 
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
-
-    DAILY_MESSAGE_LIMIT = notifications_utils.DAILY_MESSAGE_LIMIT
 
     HIGH_VOLUME_SERVICE = json.loads(getenv('HIGH_VOLUME_SERVICE', '[]'))
 

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ import json
 from datetime import timedelta
 from os import getenv, path
 
+import notifications_utils
 from celery.schedules import crontab
 from kombu import Exchange, Queue
 
@@ -274,6 +275,7 @@ class Config(object):
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
     HIGH_VOLUME_SERVICE = json.loads(getenv('HIGH_VOLUME_SERVICE', '[]'))
+    DAILY_MESSAGE_LIMIT = notifications_utils.DAILY_MESSAGE_LIMIT
 
     TEMPLATE_PREVIEW_API_HOST = getenv('TEMPLATE_PREVIEW_API_HOST', 'http://localhost:6013')
     TEMPLATE_PREVIEW_API_KEY = getenv('TEMPLATE_PREVIEW_API_KEY', 'my-secret-key')

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -138,21 +138,8 @@ def persist_notification(
         dao_create_notification(notification)
         if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
             current_app.logger.info('Redis enabled, querying cache key for service id: {}'.format(service.id))
-            cache_key = redis.daily_limit_cache_key(service.id)
             total_key = redis.daily_total_cache_key()
-            current_app.logger.info('Redis daily limit cache key: {}'.format(cache_key))
-            if redis_store.get(cache_key) is None:
-                current_app.logger.info('Redis daily limit cache key does not exist')
-                # if cache does not exist set the cache to 1 with an expiry of 24 hours,
-                # The cache should be set by the time we create the notification
-                # but in case it is this will make sure the expiry is set to 24 hours,
-                # where if we let the incr method create the cache it will be set a ttl.
-                redis_store.set(cache_key, 1, ex=86400)
-                current_app.logger.info('Set redis daily limit cache key to 1')
-            else:
-                current_app.logger.info('Redis daily limit cache key does exist')
-                redis_store.incr(cache_key)
-                current_app.logger.info('Redis daily limit cache key has been incremented')
+
             if redis_store.get(total_key) is None:
                 current_app.logger.info('Redis daily total cache key does not exist')
                 redis_store.set(total_key, 1, ex=86400)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,7 +1,10 @@
 from flask import current_app
 from gds_metrics.metrics import Histogram
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
-from notifications_utils.clients.redis import rate_limit_cache_key
+from notifications_utils.clients.redis import (
+    daily_total_cache_key,
+    rate_limit_cache_key,
+)
 from notifications_utils.recipients import (
     get_international_phone_info,
     validate_and_format_email_address,
@@ -16,6 +19,7 @@ from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEAM,
+    KEY_TYPE_TEST,
     SMS_TYPE,
     ServicePermission,
 )
@@ -25,7 +29,7 @@ from app.notifications.process_notifications import (
 from app.serialised_models import SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
 from app.utils import get_public_notify_type_text
-from app.v2.errors import BadRequestError, RateLimitError
+from app.v2.errors import BadRequestError, RateLimitError, TotalRequestsError
 
 REDIS_EXCEEDED_RATE_LIMIT_DURATION_SECONDS = Histogram(
     'redis_exceeded_rate_limit_duration_seconds',
@@ -45,6 +49,7 @@ def check_service_over_api_rate_limit(service, api_key):
 
 
 def check_rate_limiting(service, api_key):
+    check_application_over_daily_message_total(api_key.key_type, service)
     check_service_over_api_rate_limit(service, api_key)
 
 
@@ -71,6 +76,27 @@ def service_can_send_to_recipient(send_to, key_type, service, allow_guest_list_r
                 '– see https://www.notifications.service.gov.uk/trial-mode'
             )
         raise BadRequestError(message=message)
+
+    if key_type == KEY_TYPE_TEST or not current_app.config['REDIS_ENABLED']:
+        return 0
+
+
+def check_application_over_daily_message_total(key_type, service):
+    cache_key = daily_total_cache_key()
+    daily_message_limit = current_app.config['DAILY_MESSAGE_LIMIT']
+    total_stats = redis_store.get(cache_key)
+    if total_stats is None:
+        # first message of the day, set the cache to 0 and the expiry to 24 hours
+        total_stats = 0
+        redis_store.set(cache_key, total_stats, ex=86400)
+        return total_stats
+    if int(total_stats) >= daily_message_limit:
+        current_app.logger.info(
+            "while sending for service {}, daily message limit of {} reached".format(
+                service.id, daily_message_limit)
+        )
+        raise TotalRequestsError(daily_message_limit)
+    return int(total_stats)
 
 
 def service_has_permission(notify_type, permissions):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,11 +1,7 @@
 from flask import current_app
 from gds_metrics.metrics import Histogram
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
-from notifications_utils.clients.redis import (
-    daily_limit_cache_key,
-    daily_total_cache_key,
-    rate_limit_cache_key,
-)
+from notifications_utils.clients.redis import rate_limit_cache_key
 from notifications_utils.recipients import (
     get_international_phone_info,
     validate_and_format_email_address,
@@ -20,7 +16,6 @@ from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEAM,
-    KEY_TYPE_TEST,
     SMS_TYPE,
     ServicePermission,
 )
@@ -30,12 +25,7 @@ from app.notifications.process_notifications import (
 from app.serialised_models import SerialisedTemplate
 from app.service.utils import service_allowed_to_send_to
 from app.utils import get_public_notify_type_text
-from app.v2.errors import (
-    BadRequestError,
-    RateLimitError,
-    TooManyRequestsError,
-    TotalRequestsError,
-)
+from app.v2.errors import BadRequestError, RateLimitError
 
 REDIS_EXCEEDED_RATE_LIMIT_DURATION_SECONDS = Histogram(
     'redis_exceeded_rate_limit_duration_seconds',
@@ -54,51 +44,8 @@ def check_service_over_api_rate_limit(service, api_key):
                 raise RateLimitError(rate_limit, interval, api_key.key_type)
 
 
-def check_service_over_daily_message_limit(key_type, service):
-    if key_type == KEY_TYPE_TEST or not current_app.config['REDIS_ENABLED']:
-        return 0
-
-    cache_key = daily_limit_cache_key(service.id)
-    service_stats = redis_store.get(cache_key)
-    if service_stats is None:
-        # first message of the day, set the cache to 0 and the expiry to 24 hours
-        service_stats = 0
-        redis_store.set(cache_key, service_stats, ex=86400)
-        return service_stats
-    if int(service_stats) >= service.message_limit:
-        current_app.logger.info(
-            "service {} has been rate limited for daily use sent {} limit {}".format(
-                service.id, int(service_stats), service.message_limit)
-        )
-        raise TooManyRequestsError(service.message_limit)
-    return int(service_stats)
-
-
-def check_application_over_daily_message_total(key_type, service):
-    if key_type == KEY_TYPE_TEST or not current_app.config['REDIS_ENABLED']:
-        return 0
-
-    cache_key = daily_total_cache_key()
-    daily_message_limit = current_app.config['DAILY_MESSAGE_LIMIT']
-    total_stats = redis_store.get(cache_key)
-    if total_stats is None:
-        # first message of the day, set the cache to 0 and the expiry to 24 hours
-        total_stats = 0
-        redis_store.set(cache_key, total_stats, ex=86400)
-        return total_stats
-    if int(total_stats) >= daily_message_limit:
-        current_app.logger.info(
-            "while sending for service {}, daily message limit of {} reached".format(
-                service.id, daily_message_limit)
-        )
-        raise TotalRequestsError(daily_message_limit)
-    return int(total_stats)
-
-
 def check_rate_limiting(service, api_key):
     check_service_over_api_rate_limit(service, api_key)
-    check_application_over_daily_message_total(api_key.key_type, service)
-    check_service_over_daily_message_limit(api_key.key_type, service)
 
 
 def check_template_is_for_notification_type(notification_type, template_type):

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -12,7 +12,6 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.notifications.validators import (
-    check_service_over_daily_message_limit,
     validate_and_format_recipient,
     validate_template,
 )
@@ -44,8 +43,6 @@ def send_one_off_notification(service_id, post_data):
     personalisation = post_data.get('personalisation', None)
 
     validate_template(template.id, personalisation, service, template.template_type)
-
-    check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
 
     validate_and_format_recipient(
         send_to=post_data['to'],

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -172,8 +172,6 @@ def test_persist_notification_cache_is_not_incremented_on_failure_to_create_noti
 def test_persist_notification_does_not_increment_cache_if_test_key(
         notify_api, sample_template, sample_job, mocker, sample_test_api_key
 ):
-    daily_limit_cache = mocker.patch('app.notifications.process_notifications.redis_store.incr')
-
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 0
     with set_config(notify_api, 'REDIS_ENABLED', True):
@@ -192,8 +190,6 @@ def test_persist_notification_does_not_increment_cache_if_test_key(
         )
 
     assert Notification.query.count() == 1
-
-    assert not daily_limit_cache.called
 
 
 @pytest.mark.parametrize('restricted_service', [True, False])
@@ -218,39 +214,9 @@ def test_persist_notification_increments_cache_for_trial_or_live_service(
             key_type=api_key.key_type,
             reference="ref2")
 
-        assert mock_incr.call_count == 2
+        assert mock_incr.call_count == 1
         mock_incr.assert_has_calls([
-            call(str(service.id) + "-2016-01-01-count", ),
             call("2016-01-01-total", )
-        ])
-
-
-@pytest.mark.parametrize('restricted_service', [True, False])
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_sets_daily_limit_cache_if_one_does_not_exists(
-        notify_api, notify_db_session, mocker, restricted_service
-):
-    service = create_service(restricted=restricted_service)
-    template = create_template(service=service)
-    api_key = create_api_key(service=service)
-    mocker.patch('app.notifications.process_notifications.redis_store.get', return_value=None)
-    mock_set = mocker.patch('app.notifications.process_notifications.redis_store.set')
-    with set_config(notify_api, 'REDIS_ENABLED', True):
-        persist_notification(
-            template_id=template.id,
-            template_version=template.version,
-            recipient='+447111111122',
-            service=template.service,
-            personalisation={},
-            notification_type='sms',
-            api_key_id=api_key.id,
-            key_type=api_key.key_type,
-            reference="ref2")
-
-        assert mock_set.call_count == 2
-        mock_set.assert_has_calls([
-            call(str(service.id) + "-2016-01-01-count", 1, ex=86400),
-            call("2016-01-01-total", 1, ex=86400)
         ])
 
 

--- a/tests/app/service/send_notification/test_send_one_off_notification.py
+++ b/tests/app/service/send_notification/test_send_one_off_notification.py
@@ -19,7 +19,7 @@ from app.models import (
     ServiceGuestList,
 )
 from app.service.send_notification import send_one_off_notification
-from app.v2.errors import BadRequestError, TooManyRequestsError
+from app.v2.errors import BadRequestError
 from tests.app.db import (
     create_reply_to_email,
     create_service,
@@ -233,24 +233,6 @@ def test_send_one_off_notification_raises_if_cant_send_to_recipient(
         send_one_off_notification(service.id, post_data)
 
     assert 'service is in trial mode' in e.value.message
-
-
-def test_send_one_off_notification_raises_if_over_limit(notify_db_session, mocker):
-    service = create_service(message_limit=0)
-    template = create_template(service=service)
-    mocker.patch(
-        'app.service.send_notification.check_service_over_daily_message_limit',
-        side_effect=TooManyRequestsError(1)
-    )
-
-    post_data = {
-        'template_id': str(template.id),
-        'to': '07700 900 001',
-        'created_by': str(service.created_by_id)
-    }
-
-    with pytest.raises(TooManyRequestsError):
-        send_one_off_notification(service.id, post_data)
 
 
 def test_send_one_off_notification_raises_if_message_too_long(persist_mock, notify_db_session):


### PR DESCRIPTION
Remove daily limit check and fix tests.

Remove daily limit from display.

Adjust "GLOBAL_SERVICE_MESSAGE_LIMIT" to default of 250000.