### PR TITLE
Create simpler compliance artifacts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,7 +92,12 @@ jobs:
       - name: Install bandit
         run: pip install bandit
       - name: Run scan
-        run: bandit -r app/ --confidence-level medium
+        run: bandit -r app/ -f txt -o /tmp/bandit-output.txt --confidence-level medium
+      - name: Upload bandit artifact
+        uses: action/upload-artifact@v3
+        with:
+          name: bandit-report
+          path: /tmp/bandit-output.txt
 
   dynamic-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,11 +78,6 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.6
         with:
           inputs: requirements.txt
-      - name: Upload pip-audit artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: pip-audit-report
-          path: /tmp/pip-audit-output.txt
 
   static-scan:
     runs-on: ubuntu-latest
@@ -92,12 +87,7 @@ jobs:
       - name: Install bandit
         run: pip install bandit
       - name: Run scan
-        run: bandit -r app/ -f txt -o /tmp/bandit-output.txt --confidence-level medium
-      - name: Upload bandit artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: bandit-report
-          path: /tmp/bandit-output.txt
+        run: bandit -r app/ --confidence-level medium
 
   dynamic-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run scan
         run: bandit -r app/ -f txt -o /tmp/bandit-output.txt --confidence-level medium
       - name: Upload bandit artifact
-        uses: action/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: bandit-report
           path: /tmp/bandit-output.txt

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,6 +78,11 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.6
         with:
           inputs: requirements.txt
+      - name: Upload pip-audit artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pip-audit-report
+          path: /tmp/pip-audit-output.txt
 
   static-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -44,7 +44,12 @@ jobs:
       - name: Install bandit
         run: pip install bandit
       - name: Run scan
-        run: bandit -r app/ --confidence-level medium
+        run: bandit -r app/ -f txt -o /tmp/bandit-output.txt --confidence-level medium
+      - name: Upload bandit artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bandit-report
+          path: /tmp/bandit-output.txt
 
   dynamic-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -30,6 +30,11 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.6
         with:
           inputs: requirements.txt
+      - name: Upload pip-audit artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pip-audit-report
+          path: /tmp/pip-audit-output.txt
 
   static-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds 2 new artifacts to the daily scan action, a `pip-audit` report and a `bandit` report. These were previously only available as part of the full log export. It's the same information, but now cleaner for more courteous compliance.