### PR TITLE
notify-admin-638 fail if code coverage below current level of 88%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: ## Run tests and create coverage report
 	pipenv run flake8 .
 	pipenv run isort --check-only ./app ./tests
 	pipenv run coverage run --omit=*/notifications_utils/* -m pytest --maxfail=10
-	pipenv run coverage report --fail-under=50
+	pipenv run coverage report --fail-under=88
 	pipenv run coverage html -d .coverage_cache
 
 .PHONY: freeze-requirements


### PR DESCRIPTION
Failing if code coverage was below a threshold was already part of the GitHub checks, but the fail threshold was set to 50%.  Increase the threshold to the current level of code coverage (88%).