### PR TITLE
notify-api-387 Scan projects for unused code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,6 +46,8 @@ jobs:
       run: pipenv run flake8 .
     - name: Check imports alphabetized
       run: pipenv run isort --check-only ./app ./tests
+    - name: Check for dead code
+      run: make dead-code
     - name: Run tests with coverage
       run: pipenv run coverage run --omit=*/notifications_utils/* -m pytest -n4 --maxfail=10
       env:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ run-celery: ## Run celery, TODO remove purge for staging/prod
 		--loglevel=INFO \
 		--concurrency=4
 
+
+.PHONY: dead-code
+dead-code:
+	pipenv run vulture ./app --min-confidence=100
+
 .PHONY: run-celery-beat
 run-celery-beat: ## Run celery beat
 	pipenv run celery \

--- a/Pipfile
+++ b/Pipfile
@@ -61,6 +61,7 @@ gds-metrics = {version = "==0.2.4", ref = "6f1840a57b6fb1ee40b7e84f2f18ec229de8a
 packaging = "==23.1"
 notifications-utils = {editable = true, ref = "main", git = "https://github.com/GSA/notifications-utils.git"}
 newrelic = "*"
+vulture = "==2.7"
 
 [dev-packages]
 exceptiongroup = "==1.1.2"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -357,17 +357,17 @@ def setup_sqlalchemy_events(app):
     # need this or db.engine isn't accessible
     with app.app_context():
         @event.listens_for(db.engine, 'connect')
-        def connect(dbapi_connection, connection_record):
+        def connect():
             # connection first opened with db
             TOTAL_DB_CONNECTIONS.inc()
 
         @event.listens_for(db.engine, 'close')
-        def close(dbapi_connection, connection_record):
+        def close():
             # connection closed (probably only happens with overflow connections)
             TOTAL_DB_CONNECTIONS.dec()
 
         @event.listens_for(db.engine, 'checkout')
-        def checkout(dbapi_connection, connection_record, connection_proxy):
+        def checkout(connection_record):
             try:
                 # connection given to a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.inc()
@@ -405,7 +405,7 @@ def setup_sqlalchemy_events(app):
                 current_app.logger.exception("Exception caught for checkout event.")
 
         @event.listens_for(db.engine, 'checkin')
-        def checkin(dbapi_connection, connection_record):
+        def checkin(connection_record):
             try:
                 # connection returned by a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.dec()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -357,17 +357,17 @@ def setup_sqlalchemy_events(app):
     # need this or db.engine isn't accessible
     with app.app_context():
         @event.listens_for(db.engine, 'connect')
-        def connect():
+        def connect(dbapi_connection, connection_record): # noqa
             # connection first opened with db
             TOTAL_DB_CONNECTIONS.inc()
 
         @event.listens_for(db.engine, 'close')
-        def close():
+        def close(dbapi_connection, connection_record): # noqa
             # connection closed (probably only happens with overflow connections)
             TOTAL_DB_CONNECTIONS.dec()
 
         @event.listens_for(db.engine, 'checkout')
-        def checkout(connection_record):
+        def checkout(dbapi_connection, connection_record, connection_proxy): # noqa
             try:
                 # connection given to a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.inc()
@@ -405,7 +405,7 @@ def setup_sqlalchemy_events(app):
                 current_app.logger.exception("Exception caught for checkout event.")
 
         @event.listens_for(db.engine, 'checkin')
-        def checkin(connection_record):
+        def checkin(dbapi_connection, connection_record): # noqa
             try:
                 # connection returned by a web worker
                 TOTAL_CHECKED_OUT_DB_CONNECTIONS.dec()

--- a/app/commands.py
+++ b/app/commands.py
@@ -572,8 +572,9 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
             print(f'update service {service.id} with default')
             set_default_free_allowance_for_service(service, year)
 
-
-def validate_mobile(ctx, param, value):
+# We use noqa to protect this method from the vulture dead code check.  Otherwise, the params ctx and param
+# will trigger vulture and cause a build failure.
+def validate_mobile(ctx, param, value): # noqa
     if (len(''.join(i for i in value if i.isdigit())) != 10):
         raise click.BadParameter("mobile number must have 10 digits")
     else:


### PR DESCRIPTION
The vulture tool currently only finds a handful of 'unused' variables.  Removing them is problematical, so I used # noqa because otherwise vulture will fail the build. 