### PR TITLE
Switch to using FIPS-enabled endpoints

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -20,10 +20,9 @@ def get_s3_object(
     session = Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
-        region_name=region,
-        config=AWS_CLIENT_CONFIG
+        region_name=region
     )
-    s3 = session.resource('s3')
+    s3 = session.resource('s3', config=AWS_CLIENT_CONFIG)
     return s3.Object(bucket_name, file_location)
 
 

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -2,6 +2,8 @@ import botocore
 from boto3 import Session
 from flask import current_app
 
+from app.clients import AWS_CLIENT_CONFIG
+
 FILE_LOCATION_STRUCTURE = 'service-{}-notify/{}.csv'
 
 
@@ -15,7 +17,12 @@ def get_s3_file(
 def get_s3_object(
     bucket_name, file_location, access_key, secret_key, region
 ):
-    session = Session(aws_access_key_id=access_key, aws_secret_access_key=secret_key, region_name=region)
+    session = Session(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=AWS_CLIENT_CONFIG
+    )
     s3 = session.resource('s3')
     return s3.Object(bucket_name, file_location)
 

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -1,3 +1,19 @@
+from botocore.config import Config
+
+AWS_CLIENT_CONFIG = Config(
+    # This config is required to enable S3 to connect to FIPS-enabled
+    # endpoints.  See https://aws.amazon.com/compliance/fips/ for more
+    # information.
+    s3={
+        'addressing_style': 'virtual',
+    },
+    use_fips_endpoint=True
+)
+STATISTICS_REQUESTED = 'requested'
+STATISTICS_DELIVERED = 'delivered'
+STATISTICS_FAILURE = 'failure'
+
+
 class ClientException(Exception):
     '''
     Base Exceptions for sending notifications that fail
@@ -10,11 +26,6 @@ class Client(object):
     Base client for sending notifications.
     '''
     pass
-
-
-STATISTICS_REQUESTED = 'requested'
-STATISTICS_DELIVERED = 'delivered'
-STATISTICS_FAILURE = 'failure'
 
 
 class NotificationProviderClients(object):

--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -4,7 +4,7 @@ import time
 
 from boto3 import client
 
-from app.clients import Client
+from app.clients import AWS_CLIENT_CONFIG, Client
 from app.cloudfoundry_config import cloud_config
 
 
@@ -18,7 +18,8 @@ class AwsCloudwatchClient(Client):
             "logs",
             region_name=cloud_config.sns_region,
             aws_access_key_id=cloud_config.sns_access_key,
-            aws_secret_access_key=cloud_config.sns_secret_key
+            aws_secret_access_key=cloud_config.sns_secret_key,
+            config=AWS_CLIENT_CONFIG
         )
         super(Client, self).__init__(*args, **kwargs)
         self.current_app = current_app

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -4,7 +4,11 @@ import botocore
 from boto3 import client
 from flask import current_app
 
-from app.clients import STATISTICS_DELIVERED, STATISTICS_FAILURE
+from app.clients import (
+    AWS_CLIENT_CONFIG,
+    STATISTICS_DELIVERED,
+    STATISTICS_FAILURE,
+)
 from app.clients.email import (
     EmailClient,
     EmailClientException,
@@ -62,7 +66,8 @@ class AwsSesClient(EmailClient):
             'ses',
             region_name=cloud_config.ses_region,
             aws_access_key_id=cloud_config.ses_access_key,
-            aws_secret_access_key=cloud_config.ses_secret_key
+            aws_secret_access_key=cloud_config.ses_secret_key,
+            config=AWS_CLIENT_CONFIG
         )
         super(AwsSesClient, self).__init__(*args, **kwargs)
 

--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -5,6 +5,7 @@ import botocore
 import phonenumbers
 from boto3 import client
 
+from app.clients import AWS_CLIENT_CONFIG
 from app.clients.sms import SmsClient
 from app.cloudfoundry_config import cloud_config
 
@@ -19,7 +20,8 @@ class AwsSnsClient(SmsClient):
             "sns",
             region_name=cloud_config.sns_region,
             aws_access_key_id=cloud_config.sns_access_key,
-            aws_secret_access_key=cloud_config.sns_secret_key
+            aws_secret_access_key=cloud_config.sns_secret_key,
+            config=AWS_CLIENT_CONFIG
         )
         super(SmsClient, self).__init__(*args, **kwargs)
         self.current_app = current_app

--- a/deploy-config/egress_proxy/notify-api-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-demo.allow.acl
@@ -1,14 +1,10 @@
-logs.us-east-1.amazonaws.com
 logs-fips.us-east-1.amazonaws.com
-monitoring.us-west-2.amazonaws.com
 monitoring-fips.us-west-2.amazonaws.com
-email.us-west-2.amazonaws.com
 email-fips.us-west-2.amazonaws.com
 s3-fips.us-east-1.amazonaws.com
 s3-fips.us-east-2.amazonaws.com
 s3-fips.us-west-1.amazonaws.com
 s3-fips.us-west-2.amazonaws.com
-sns.us-east-1.amazonaws.com
 sns-fips.us-east-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-demo.apps.internal

--- a/deploy-config/egress_proxy/notify-api-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-demo.allow.acl
@@ -1,5 +1,14 @@
+logs.us-east-1.amazonaws.com
+logs-fips.us-east-1.amazonaws.com
 monitoring.us-west-2.amazonaws.com
+monitoring-fips.us-west-2.amazonaws.com
 email.us-west-2.amazonaws.com
+email-fips.us-west-2.amazonaws.com
+s3-fips.us-east-1.amazonaws.com
+s3-fips.us-east-2.amazonaws.com
+s3-fips.us-west-1.amazonaws.com
+s3-fips.us-west-2.amazonaws.com
 sns.us-east-1.amazonaws.com
+sns-fips.us-east-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-demo.apps.internal

--- a/deploy-config/egress_proxy/notify-api-production.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-production.allow.acl
@@ -1,5 +1,9 @@
+logs.us-gov-west-1.amazonaws.com
 monitoring.us-west-2.amazonaws.com
 email.us-gov-west-1.amazonaws.com
+email-fips.us-gov-west-1.amazonaws.com
+s3-fips.us-gov-east-1.amazonaws.com
+s3-fips.us-gov-west-1.amazonaws.com
 sns.us-gov-west-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-production.apps.internal

--- a/deploy-config/egress_proxy/notify-api-production.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-production.allow.acl
@@ -1,6 +1,6 @@
 logs.us-gov-west-1.amazonaws.com
-monitoring.us-west-2.amazonaws.com
-email.us-gov-west-1.amazonaws.com
+monitoring-fips.us-west-2.amazonaws.com
+monitoring.us-gov-west-1.amazonaws.com
 email-fips.us-gov-west-1.amazonaws.com
 s3-fips.us-gov-east-1.amazonaws.com
 s3-fips.us-gov-west-1.amazonaws.com

--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -1,14 +1,10 @@
-logs.us-west-2.amazonaws.com
 logs-fips.us-west-2.amazonaws.com
-monitoring.us-west-2.amazonaws.com
 monitoring-fips.us-west-2.amazonaws.com
-email.us-west-2.amazonaws.com
 email-fips.us-west-2.amazonaws.com
 s3-fips.us-east-1.amazonaws.com
 s3-fips.us-east-2.amazonaws.com
 s3-fips.us-west-1.amazonaws.com
 s3-fips.us-west-2.amazonaws.com
-sns.us-west-2.amazonaws.com
 sns-fips.us-west-2.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-staging.apps.internal

--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -1,6 +1,14 @@
 logs.us-west-2.amazonaws.com
+logs-fips.us-west-2.amazonaws.com
 monitoring.us-west-2.amazonaws.com
+monitoring-fips.us-west-2.amazonaws.com
 email.us-west-2.amazonaws.com
+email-fips.us-west-2.amazonaws.com
+s3-fips.us-east-1.amazonaws.com
+s3-fips.us-east-2.amazonaws.com
+s3-fips.us-west-1.amazonaws.com
+s3-fips.us-west-2.amazonaws.com
 sns.us-west-2.amazonaws.com
+sns-fips.us-west-2.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-staging.apps.internal


### PR DESCRIPTION
Addresses #274

This changeset switches AWS service touchpoints to use their FIPS-enabled counterparts.  Note that S3 has some specific configuration associated with it.

This changeset also updates our allow ACLs to cover the FIPS-enabled endpoints.  We should investigate removing the non-FIPS endpoints as a part of this.

## Security Considerations

- Helps ensure security compliance of our system by switching to the FIPS-enabled AWS endpoints.