### PR TITLE
Update cloud.gov org references

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-        cf_org: gsa-tts-benefits-studio-prototyping
+        cf_org: gsa-tts-benefits-studio
         cf_space: notify-demo
         push_arguments: >-
           --vars-file deploy-config/demo.yml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-        cf_org: gsa-tts-benefits-studio-prototyping
+        cf_org: gsa-tts-benefits-studio
         cf_space: notify-production
         push_arguments: >-
           --vars-file deploy-config/production.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-        cf_org: gsa-tts-benefits-studio-prototyping
+        cf_org: gsa-tts-benefits-studio
         cf_space: notify-staging
         push_arguments: >-
           --vars-file deploy-config/staging.yml

--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}
           full_command: "cf restage --strategy rolling notify-${{matrix.app}}-${{inputs.environment}}"
       - name: Restage ${{matrix.app}} egress
@@ -31,6 +31,6 @@ jobs:
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}-egress
           full_command: "cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}"

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -5,7 +5,7 @@ locals {
 module "s3" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.3.0"
 
-  cf_org_name   = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name   = "gsa-tts-benefits-studio"
   cf_space_name = "notify-management"
   name          = local.s3_service_name
 }

--- a/terraform/create_service_account.sh
+++ b/terraform/create_service_account.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Create a Service User Account for a given space

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-demo"
   env              = "demo"
   app_name         = "notify-api"

--- a/terraform/destroy_service_account.sh
+++ b/terraform/destroy_service_account.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Destroy a Service User Account in a given space

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-local-dev"
   recursive_delete = true
   key_name         = "${var.username}-api-dev-key"

--- a/terraform/development/reset.sh
+++ b/terraform/development/reset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 username=`whoami`
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Reset terraform state so run.sh can be run again or for a new username

--- a/terraform/development/run.sh
+++ b/terraform/development/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 username=`whoami`
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Create development infrastructure

--- a/terraform/ops/cloudgov_user_report.py
+++ b/terraform/ops/cloudgov_user_report.py
@@ -2,7 +2,7 @@ from subprocess import check_output
 
 from cloudfoundry_client.client import CloudFoundryClient
 
-ORG_NAME = "gsa-tts-benefits-studio-prototyping"
+ORG_NAME = "gsa-tts-benefits-studio"
 
 
 client = CloudFoundryClient.build_from_cf_config()

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-production"
   env              = "production"
   app_name         = "notify-api"
@@ -75,7 +75,7 @@ module "sns_sms" {
 # TODO: decide on public API domain name
 # 1) the app has first been deployed
 # 2) the route has been manually created by an OrgManager:
-#     `cf create-domain gsa-tts-benefits-studio-prototyping api.notify.gov`
+#     `cf create-domain gsa-tts-benefits-studio api.notify.gov`
 ###########################################################################
 # module "domain" {
 #   source = "github.com/18f/terraform-cloudgov//domain?ref=v0.2.0"

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-sandbox"
   env              = "sandbox"
   app_name         = "notify-api"

--- a/terraform/set_space_egress.sh
+++ b/terraform/set_space_egress.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-org="gsa-tts-benefits-studio-prototyping"
+org="gsa-tts-benefits-studio"
 
 usage="
 $0: Set egress rules for given space

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio-prototyping"
+  cf_org_name      = "gsa-tts-benefits-studio"
   cf_space_name    = "notify-staging"
   env              = "staging"
   app_name         = "notify-api"


### PR DESCRIPTION
Part of #439

This changeset adjusts our references to the cloud.gov org we are using from gsa-tts-benefits-studio-prototyping to gsa-tts-benefits-studio.

## Security Considerations

- None for this change.