### PR TITLE
Insert total_message_limit into service creation

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -216,6 +216,8 @@ def create_service():
         raise InvalidRequest(errors, status_code=400)
     data.pop("service_domain", None)
 
+    data["total_message_limit"] = current_app.config["TOTAL_MESSAGE_LIMIT"]
+
     # validate json with marshmallow
     service_schema.load(data)
 


### PR DESCRIPTION
This fixes an error where the API expected a `total_message_limit`, but the UI was not sending one. We are hard-coding it, as it is not user-settable, but this is likely to change in the future as we revise limit handling.