### PR TITLE
add migration for e2e tests and improve code coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,6 +52,10 @@ jobs:
       run: poetry run coverage run --omit=*/notifications_utils/* -m pytest --maxfail=10
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+        NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+        NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
+        NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
+        NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
     - name: Check coverage threshold
       run: poetry run coverage report --fail-under=50
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,10 @@ jobs:
       run: make bootstrap
       env:
         SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+        NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+        NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
+        NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
+        NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
     - name: Run style checks
       run: poetry run flake8 .
     - name: Check imports alphabetized

--- a/migrations/versions/0401_add_e2e_test_user.py
+++ b/migrations/versions/0401_add_e2e_test_user.py
@@ -1,0 +1,45 @@
+"""
+
+Revision ID: 0400_add_total_message_limit
+Revises: 0399_remove_research_mode
+Create Date: 2023-04-24 11:35:22.873930
+
+"""
+import os
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+from app import db
+from app.dao.users_dao import get_user_by_email
+from app.models import User
+
+revision = "0401_add_e2e_test_user"
+down_revision = "0400_add_total_message_limit"
+
+
+def upgrade():
+    email_address = os.getenv("NOTIFY_E2E_TEST_EMAIL")
+    password = os.getenv("NOTIFY_E2E_TEST_PASSWORD")
+    name = f"e2e_test_user_{uuid.uuid4()}"
+    data = {
+        "id": uuid.uuid4(),
+        "name": name,
+        "email_address": email_address,
+        "password": password,
+        "mobile_number": "+12025555555",
+        "state": "active",
+    }
+    user = User(**data)
+    db.session.add(user)
+    db.session.commit()
+
+
+def downgrade():
+    email_address = os.getenv("NOTIFY_E2E_TEST_EMAIL")
+    user_to_delete = get_user_by_email(email_address)
+    if not user_to_delete:
+        return
+    db.session.remove(user_to_delete)
+    db.session.commit()

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -1,7 +1,11 @@
+import os
 from datetime import datetime
 from os import getenv
 
-from app.aws.s3 import get_s3_file
+import pytest
+from botocore.exceptions import ClientError
+
+from app.aws.s3 import file_exists, get_s3_file, remove_csv_object, remove_s3_object
 
 default_access_key = getenv("CSV_AWS_ACCESS_KEY_ID")
 default_secret_key = getenv("CSV_AWS_SECRET_ACCESS_KEY")
@@ -29,6 +33,85 @@ def test_get_s3_file_makes_correct_call(notify_api, mocker):
     get_s3_mock.assert_called_with(
         "foo-bucket",
         "bar-file.txt",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+
+
+def test_remove_csv_object(notify_api, mocker):
+    get_s3_mock = mocker.patch("app.aws.s3.get_s3_object")
+    remove_csv_object("mykey")
+
+    get_s3_mock.assert_called_once_with(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+
+
+def test_remove_csv_object_alternate(notify_api, mocker):
+    get_s3_mock = mocker.patch("app.aws.s3.get_s3_object")
+    remove_s3_object(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+
+    get_s3_mock.assert_called_once_with(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+
+
+def test_file_exists_true(notify_api, mocker):
+    get_s3_mock = mocker.patch("app.aws.s3.get_s3_object")
+
+    file_exists(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+    get_s3_mock.assert_called_once_with(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
+        default_access_key,
+        default_secret_key,
+        default_region,
+    )
+
+
+def test_file_exists_false(notify_api, mocker):
+    get_s3_mock = mocker.patch("app.aws.s3.get_s3_object")
+    error_response = {
+        "Error": {"Code": 500, "Message": "bogus"},
+        "ResponseMetadata": {"HTTPStatusCode": 500},
+    }
+    get_s3_mock.side_effect = ClientError(
+        error_response=error_response, operation_name="bogus"
+    )
+
+    with pytest.raises(ClientError):
+        file_exists(
+            os.getenv("CSV_BUCKET_NAME"),
+            "mykey",
+            default_access_key,
+            default_secret_key,
+            default_region,
+        )
+
+    get_s3_mock.assert_called_once_with(
+        os.getenv("CSV_BUCKET_NAME"),
+        "mykey",
         default_access_key,
         default_secret_key,
         default_region,

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -5,7 +5,7 @@ from notifications_utils import SMS_CHAR_COUNT_LIMIT
 
 import app
 from app.dao import templates_dao
-from app.models import EMAIL_TYPE, SMS_TYPE
+from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, SMS_TYPE
 from app.notifications.process_notifications import create_content_for_notification
 from app.notifications.sns_cert_validator import (
     VALID_SNS_TOPICS,
@@ -21,6 +21,7 @@ from app.notifications.validators import (
     check_reply_to,
     check_service_email_reply_to_id,
     check_service_over_api_rate_limit,
+    check_service_over_total_message_limit,
     check_service_sms_sender_id,
     check_template_is_active,
     check_template_is_for_notification_type,
@@ -727,3 +728,12 @@ def test_get_string_to_sign():
     # This is a test payload with no valid cert, so it should raise a ValueError
     with pytest.raises(ValueError):
         validate_sns_cert(sns_payload)
+
+
+def test_check_service_over_total_message_limit(mocker, sample_service):
+    get_redis_mock = mocker.patch("app.notifications.validators.redis_store.get")
+    get_redis_mock.return_value = None
+    service_stats = check_service_over_total_message_limit(
+        KEY_TYPE_NORMAL, sample_service
+    )
+    assert service_stats == 0


### PR DESCRIPTION
This is the migration script to set up the e2e test user.  It works fine locally, but remotely the build is failing because password is None.  The password is set here:


    password = os.getenv("NOTIFY_E2E_TEST_PASSWORD")
    
So I'm thinking the environment variable may not be set wherever this builds.  However, I don't have permission to view secrets in GitHub, so can't check.