### PR TITLE
Update ADR-0003 (Invite Expirations)

### DIFF
--- a/docs/adrs/0003-implementing-invite-expirations.md
+++ b/docs/adrs/0003-implementing-invite-expirations.md
@@ -3,7 +3,7 @@
 
 | CREATED DATE | LAST UPDATED | STATUS | AUTHOR | STAKEHOLDERS |
 | :---: | :---: | :---: | :---: | :---: |
-| 06/06/2023 | 06/15/2023 | Proposed | @ccostino | @GSA/notify-contributors |
+| 06/06/2023 | 09/15/2023 | Accepted | @ccostino | @GSA/notify-contributors |
 
 
 ## CONTEXT AND PROBLEM STATEMENT
@@ -48,8 +48,7 @@ that are already in place, which prevent the following:
 
 ## CONSIDERED OPTIONS
 
-These are the different approaches we're considering for implementing this
-change:
+This is the approach we've considered for implementing this change:
 
 - **Adjust `InvitedUser` management in the API:**  Instead of deleting
   `InvitedUser` objects, we manage them instead and track their `created_at`
@@ -107,8 +106,6 @@ value for the effort.
 
 
 ## VALIDATION AND NEXT STEPS
-
-TBD, pending additional ideas and discussion!
 
 Once a decision is made though, a seperate issue should be written up for the
 API changes that need to take place, and then follow-on work will be needed on

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -180,8 +180,9 @@ top!).
 
 | ADR | TITLE | CURRENT STATUS | IMPLEMENTED | LAST MODIFIED |
 | :---: | :---: | :---: | :---: | :---: |
+| [ADR-0006](./0006-use-for-dependency-management.md) | [Use `poetry` for Dependency Management](./0006-use-for-dependency-management.md) | Accepted | Yes | 09/08/2023 |
 | [ADR-0005](./0005-agreement-data-model.md) | [Agreement info in data model](./0005-agreement-data-model.md) | Accepted | No | 07/05/2023 |
 | [ADR-0004](./0004-designing-pilot-content-visibility.md) | [Designing Pilot Content Visibility](./0004-designing-pilot-content-visibility.md) | Proposed | No | 06/20/2023 |
-| [ADR-0003](./0003-implementing-invite-expirations.md) | [Implementing User Invite Expirations](./0003-implementing-invite-expirations.md) | Proposed | No | 06/15/2023 |
+| [ADR-0003](./0003-implementing-invite-expirations.md) | [Implementing User Invite Expirations](./0003-implementing-invite-expirations.md) | Accepted | No | 09/15/2023 |
 | [ADR-0002](./0002-how-to-handle-timezones.md) | [Determine How to Handle Timezones in US Notify](./0002-how-to-handle-timezones.md) | Accepted | Yes | 06/15/2023 |
 | [ADR-0001](./0001-establishing-adrs-for-us-notify.md) | [Establishing ADRs for US Notify](./0001-establishing-adrs-for-us-notify.md) | Accepted | Yes | 06/15/2023 |


### PR DESCRIPTION
This changest updates the Invite Expirations ADR (ADR-0003) to become accepted and ready for implementation. It also updates the index with recent ADR changes prior to the ADR process updates.

## Security Considerations

- None; the ADR documentation itself notes some concerns to be mindful but the suggestion implementation preserves user permissions and authentication checks.