### PR TITLE
Add total message limit default to existing services

### DIFF
--- a/migrations/versions/0402_total_message_limit_default.py
+++ b/migrations/versions/0402_total_message_limit_default.py
@@ -1,6 +1,6 @@
 """
 
-Revision ID: e1ca86e9c5d4
+Revision ID: 0402_total_message_limit_default
 Revises: 0401_add_e2e_test_user
 Create Date: 2023-09-18 10:04:58.957374
 

--- a/migrations/versions/0402_total_message_limit_default.py
+++ b/migrations/versions/0402_total_message_limit_default.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: e1ca86e9c5d4
+Revises: 0401_add_e2e_test_user
+Create Date: 2023-09-18 10:04:58.957374
+
+"""
+from alembic import op
+from flask import current_app
+import sqlalchemy as sa
+
+
+revision = '0402_total_message_limit_default'
+down_revision = '0401_add_e2e_test_user'
+
+
+def upgrade():
+    # Set a default value for the total_message_limit column in the
+    # services table to match the current TOTAL_MESSAGE_LIMIT app
+    # config.
+    op.execute(
+        "UPDATE services SET total_message_limit = {total_message_limit} WHERE total_message_limit IS NULL".format(
+            total_message_limit=current_app.config["TOTAL_MESSAGE_LIMIT"]
+        )
+    )
+
+
+def downgrade():
+    # There is no downgrade from this migration as it would cause a bug
+    # in the app; if it needs to be removed, then you have to remove the
+    # column added in migration 0400.
+    pass


### PR DESCRIPTION
Addresses #474

This changeset adds a migration to add a default total message limit to any pre-existing service that does not already have one set.  It bases this value on the default set in the Flask app config.

## Security Considerations

- None with this change.