### PR TITLE
Add missing environment variables from cf push

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -68,6 +68,8 @@ jobs:
           --var SECRET_KEY="$SECRET_KEY"
           --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
           --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
+          --var NOTIFY_E2E_TEST_EMAIL="$NOTIFY_E2E_TEST_EMAIL"
+          --var NOTIFY_E2E_TEST_PASSWORD="$NOTIFY_E2E_TEST_PASSWORD"
 
     - name: Check for changes to egress config
       id: changed-egress-config

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,6 +72,8 @@ jobs:
           --var SECRET_KEY="$SECRET_KEY"
           --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
           --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
+          --var NOTIFY_E2E_TEST_EMAIL="$NOTIFY_E2E_TEST_EMAIL"
+          --var NOTIFY_E2E_TEST_PASSWORD="$NOTIFY_E2E_TEST_PASSWORD"
 
     - name: Check for changes to egress config
       id: changed-egress-config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,8 @@ jobs:
           --var SECRET_KEY="$SECRET_KEY"
           --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
           --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
+          --var NOTIFY_E2E_TEST_EMAIL="$NOTIFY_E2E_TEST_EMAIL"
+          --var NOTIFY_E2E_TEST_PASSWORD="$NOTIFY_E2E_TEST_PASSWORD"
 
     - name: Check for changes to egress config
       id: changed-egress-config

--- a/manifest.yml
+++ b/manifest.yml
@@ -43,6 +43,8 @@ applications:
       NOTIFY_ENVIRONMENT: ((env))
       API_HOST_NAME: https://((public_api_route))
       ADMIN_BASE_URL: ((admin_base_url))
+      NOTIFY_E2E_TEST_EMAIL: ((NOTIFY_E2E_TEST_EMAIL))
+      NOTIFY_E2E_TEST_PASSWORD: ((NOTIFY_E2E_TEST_PASSWORD))
 
       # Credentials variables
       INTERNAL_CLIENT_API_KEYS: '{"notify-admin":["((ADMIN_CLIENT_SECRET))"]}'


### PR DESCRIPTION
This changeset actually adds the missing E2E test environment variables to the cf push command.

## Security Considerations

- Continue making sure we don't expose secrets.