### PR TITLE
Fix the dynamic-scan job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Run OWASP Baseline Scan
         uses: zaproxy/action-api-scan@v0.5.0
         with:
-          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:weekly'
           target: 'http://localhost:6011/docs/openapi.yml'
           fail_action: true
           allow_issue_writing: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -132,9 +132,9 @@ jobs:
         env:
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
       - name: Run OWASP Baseline Scan
-        uses: zaproxy/action-api-scan@v0.4.0
+        uses: zaproxy/action-api-scan@v0.5.0
         with:
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           target: 'http://localhost:6011/docs/openapi.yml'
           fail_action: true
           allow_issue_writing: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -123,6 +123,10 @@ jobs:
         run: make bootstrap
         env:
           SQLALCHEMY_DATABASE_TEST_URI: postgresql://user:password@localhost:5432/test_notification_api
+          NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_PASSWORD }}
+          NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
+          NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
       - name: Run server
         run: make run-flask &
         env:


### PR DESCRIPTION
This PR fixes the dynamic-scan job, which is now failing in our PR checks due to missing environment variables.

## Note

It appears there was a change in how the `zaproxy` Docker image was being referenced and prior to this PR, the `weekly` image was being used despite us having it configured to pull down the `stable` package.

As of the morning of this PR being created, only the `stable` package started to be pulled down, which wouldn't run correctly.  We had to explicit set the action to pull the `weekly` Docker image to get a working build again.

## Security Considerations

- Be mindful of secrets being referenced in code.