### PR TITLE
notify-api-360 stop worrying about aws regions

### DIFF
--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -80,28 +80,16 @@ class AwsCloudwatchClient(Client):
                 break
         return all_log_events
 
-    def _extract_account_number(self, ses_domain_arn, region):
-        account_number = ses_domain_arn
-        # handle cloud.gov case
-        if "aws-us-gov" in account_number:
-            account_number = account_number.replace(f"arn:aws-us-gov:ses:{region}:", "")
-            account_number = account_number.split(":")
-            account_number = account_number[0]
-        # handle staging case
-        else:
-            account_number = account_number.replace(f"arn:aws:ses:{region}:", "")
-            account_number = account_number.split(":")
-            account_number = account_number[0]
+    def _extract_account_number(self, ses_domain_arn):
+        account_number = ses_domain_arn.split(":")
         return account_number
 
     def check_sms(self, message_id, notification_id, created_at):
         region = cloud_config.sns_region
         # TODO this clumsy approach to getting the account number will be fixed as part of notify-api #258
-        account_number = self._extract_account_number(
-            cloud_config.ses_domain_arn, region
-        )
+        account_number = self._extract_account_number(cloud_config.ses_domain_arn)
 
-        log_group_name = f"sns/{region}/{account_number}/DirectPublishToPhoneNumber"
+        log_group_name = f"sns/{region}/{account_number[4]}/DirectPublishToPhoneNumber"
         current_app.logger.info(
             f"Log group name: {log_group_name} message id: {message_id}"
         )

--- a/tests/app/clients/test_aws_cloudwatch.py
+++ b/tests/app/clients/test_aws_cloudwatch.py
@@ -54,7 +54,10 @@ def test_check_sms_success(notify_api, mocker):
     aws_cloudwatch_client.init_app(current_app)
     boto_mock = mocker.patch.object(aws_cloudwatch_client, "_client", create=True)
     boto_mock.filter_log_events.side_effect = side_effect
-    mocker.patch.dict("os.environ", {"SES_DOMAIN_ARN": "1111:"})
+    mocker.patch.dict(
+        "os.environ",
+        {"SES_DOMAIN_ARN": "arn:aws:ses:us-west-2:12345:identity/ses-xxx.xxx.xxx.xxx"},
+    )
 
     message_id = "succeed"
     notification_id = "ccc"
@@ -73,8 +76,10 @@ def test_check_sms_failure(notify_api, mocker):
     aws_cloudwatch_client.init_app(current_app)
     boto_mock = mocker.patch.object(aws_cloudwatch_client, "_client", create=True)
     boto_mock.filter_log_events.side_effect = side_effect
-    mocker.patch.dict("os.environ", {"SES_DOMAIN_ARN": "1111:"})
-
+    mocker.patch.dict(
+        "os.environ",
+        {"SES_DOMAIN_ARN": "arn:aws:ses:us-west-2:12345:identity/ses-xxx.xxx.xxx.xxx"},
+    )
     message_id = "fail"
     notification_id = "bbb"
     with notify_api.app_context():
@@ -90,17 +95,15 @@ def test_check_sms_failure(notify_api, mocker):
 
 def test_extract_account_number_gov_cloud():
     domain_arn = "arn:aws-us-gov:ses:us-gov-west-1:12345:identity/ses-abc.xxx.xxx.xxx"
-    actual_account_number = aws_cloudwatch_client._extract_account_number(
-        domain_arn, "us-gov-west-1"
-    )
+    actual_account_number = aws_cloudwatch_client._extract_account_number(domain_arn)
+    assert len(actual_account_number) == 6
     expected_account_number = "12345"
-    assert actual_account_number == expected_account_number
+    assert actual_account_number[4] == expected_account_number
 
 
 def test_extract_account_number_gov_staging():
     domain_arn = "arn:aws:ses:us-south-14:12345:identity/ses-abc.xxx.xxx.xxx"
-    actual_account_number = aws_cloudwatch_client._extract_account_number(
-        domain_arn, "us-south-14"
-    )
+    actual_account_number = aws_cloudwatch_client._extract_account_number(domain_arn)
+    assert len(actual_account_number) == 6
     expected_account_number = "12345"
-    assert actual_account_number == expected_account_number
+    assert actual_account_number[4] == expected_account_number


### PR DESCRIPTION
The previous solution for "messages hang in pending forever" was attempting to do some string manipulation of an environment variable to determine what the aws account number was.  Unfortunately the demo environment used multiple regions and the sns region was different from the ses region, causing corruption of the cloudwatch log group name we were trying to construct and making it impossible to retrieve delivery receipts.

The new implementation relies on counting colons in the arn string.  The account number ice always at index 4 if you split the string by colons, whether you are in gov cloud or regular aws.