### PR TITLE
Added flag to remove default sender from user list

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -273,6 +273,7 @@ def dao_create_service(
     user,
     service_id=None,
     service_permissions=None,
+    create_default_sms_sender=False,
 ):
     if not user:
         raise ValueError("Can't create a service without a user")
@@ -297,8 +298,11 @@ def dao_create_service(
         )
         service.permissions.append(service_permission)
 
-    # do we just add the default - or will we get a value from FE?
-    insert_service_sms_sender(service, current_app.config["FROM_NUMBER"])
+    # We are removing an sms default sender from being added to each
+    # service as it is created, but we will pass a default flag
+    # because some tests need a default number.
+    if create_default_sms_sender:
+        insert_service_sms_sender(service, current_app.config["FROM_NUMBER"])
 
     if organization:
         service.organization_id = organization.id

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -226,8 +226,15 @@ def create_service():
     # unpack valid json into service object
     valid_service = Service.from_json(data)
 
+    # Grabbing flag from request object for default sms sender
+    create_default_sms_sender = bool(
+        request.args.get("create_default_sms_sender", False)
+    )
+
     with transaction():
-        dao_create_service(valid_service, user, create_default_sms_sender=True)
+        dao_create_service(
+            valid_service, user, create_default_sms_sender=create_default_sms_sender
+        )
         set_default_free_allowance_for_service(service=valid_service, year_start=None)
 
     return jsonify(data=service_schema.dump(valid_service)), 201

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -226,7 +226,8 @@ def create_service():
     # unpack valid json into service object
     valid_service = Service.from_json(data)
 
-    # Grabbing flag from request object for default sms sender
+    # Grabbing flag from request object for default SMS sender.
+    # This will only be true in our tests now; the value will default to false in normal app usage.
     create_default_sms_sender = bool(
         request.args.get("create_default_sms_sender", False)
     )

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -227,7 +227,7 @@ def create_service():
     valid_service = Service.from_json(data)
 
     with transaction():
-        dao_create_service(valid_service, user)
+        dao_create_service(valid_service, user, create_default_sms_sender=True)
         set_default_free_allowance_for_service(service=valid_service, year_start=None)
 
     return jsonify(data=service_schema.dump(valid_service)), 201

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -219,7 +219,12 @@ def sample_service(sample_user):
     service = Service.query.filter_by(name=service_name).first()
     if not service:
         service = Service(**data)
-        dao_create_service(service, sample_user, service_permissions=None)
+        dao_create_service(
+            service,
+            sample_user,
+            service_permissions=None,
+            create_default_sms_sender=True,
+        )
     else:
         if sample_user not in service.users:
             dao_add_user_to_service(service, sample_user)
@@ -241,7 +246,9 @@ def _sample_service_full_permissions(notify_db_session):
 @pytest.fixture(scope="function")
 def sample_template(sample_user):
     service = create_service(
-        service_permissions=[EMAIL_TYPE, SMS_TYPE], check_if_service_exists=True
+        service_permissions=[EMAIL_TYPE, SMS_TYPE],
+        check_if_service_exists=True,
+        create_default_sms_sender=True,
     )
 
     data = {
@@ -798,6 +805,7 @@ def notify_service(notify_db_session, sample_user):
             service=service,
             service_id=current_app.config["NOTIFY_SERVICE_ID"],
             user=sample_user,
+            create_default_sms_sender=True,
         )
 
         data = {

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -117,6 +117,7 @@ def create_service(
     billing_contact_names=None,
     billing_contact_email_addresses=None,
     billing_reference=None,
+    create_default_sms_sender=True,
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
@@ -149,6 +150,7 @@ def create_service(
             service.created_by,
             service_id,
             service_permissions=service_permissions,
+            create_default_sms_sender=create_default_sms_sender,
         )
 
         service.active = active

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -404,7 +404,6 @@ def test_create_service(
     )
 
     assert json_resp["data"]["name"] == "created service"
-    # insert_service_sms_sender(service, current_app.config["FROM_NUMBER"])
     service_sms_senders = ServiceSmsSender.query.filter_by(
         service_id=service_db.id
     ).all()

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -380,8 +380,13 @@ def test_create_service(
         "created_by": str(sample_user.id),
     }
 
+    create_default_sms_sender = True
+
     json_resp = admin_request.post(
-        "service.create_service", _data=data, _expected_status=201
+        "service.create_service",
+        _data=data,
+        _expected_status=201,
+        create_default_sms_sender=create_default_sms_sender,
     )
 
     assert json_resp["data"]["id"]
@@ -399,7 +404,7 @@ def test_create_service(
     )
 
     assert json_resp["data"]["name"] == "created service"
-
+    # insert_service_sms_sender(service, current_app.config["FROM_NUMBER"])
     service_sms_senders = ServiceSmsSender.query.filter_by(
         service_id=service_db.id
     ).all()


### PR DESCRIPTION
We decided it was best to remove the default sender from the `api` (when a service is created a default sms sender is created with it) rather than relying on removing the ability for the user to see it on the front end. This route removes the `default sms sender` from showing up when in the service settings or during the message flow on the front end.

~A migration would be the next step to remove the default sender from already existing services.~  A new issue has been created to account for the next step, which will be to create a command to run a one-off task to clean up existing services (#540).

Changes:
- Added flag to the `dao_create_service()` function to only `insert a default sms sender` when in the `test` environment.
- Fixed tests that needed the updated flag.