### PR TITLE
write a csv bucket purge command

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -22,6 +22,17 @@ def get_s3_object(bucket_name, file_location, access_key, secret_key, region):
     return s3.Object(bucket_name, file_location)
 
 
+def purge_bucket(bucket_name, access_key, secret_key, region):
+    session = Session(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+    )
+    s3 = session.resource("s3", config=AWS_CLIENT_CONFIG)
+    bucket = s3.Bucket(bucket_name)
+    bucket.objects.all().delete()
+
+
 def file_exists(bucket_name, file_location, access_key, secret_key, region):
     try:
         # try and access metadata of object

--- a/app/commands.py
+++ b/app/commands.py
@@ -845,7 +845,7 @@ def promote_user_to_platform_admin(user_email_address):
 
 @notify_command(name="purge-csv-bucket")
 def purge_csv_bucket():
-    bucket_name = getenv("CSV_BUCKEY_NAME")
+    bucket_name = getenv("CSV_BUCKET_NAME")
     access_key = getenv("CSV_AWS_ACCESS_KEY_ID")
     secret = getenv("CSV_AWS_SECRET_ACCESS_KEY")
     region = getenv("CSV_AWS_REGION")

--- a/app/commands.py
+++ b/app/commands.py
@@ -841,3 +841,14 @@ def promote_user_to_platform_admin(user_email_address):
     user.platform_admin = True
     db.session.add(user)
     db.session.commit()
+
+
+@notify_command(name="purge-csv-bucket")
+def purge_csv_bucket():
+    bucket_name = getenv("CSV_BUCKEY_NAME")
+    access_key = getenv("CSV_AWS_ACCESS_KEY_ID")
+    secret = getenv("CSV_AWS_SECRET_ACCESS_KEY")
+    region = getenv("CSV_AWS_REGION")
+    print("ABOUT TO RUN PURGE CSV BUCKET")
+    s3.purge_bucket(bucket_name, access_key, secret, region)
+    print("RAN PURGE CSV BUCKET")


### PR DESCRIPTION
Developers over time will accumulate csv files in their development csv buckets that don't get processed for whatever reason.  When this happens, it will be impossible for them to reset their admin environment via the reset.sh command, because it will fail on trying to delete the non-empty csv bucket.

Write a command that will purge the developer's csv bucket to assist with environment recovery.