### PR TITLE
Live service content says 250K per day, not per year. #85

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -139,7 +139,7 @@
       "((service name)) is now live on Notify.gov.",
       "",
       "",
-      "You can send up to ((message limit)) messages per day.",
+      "You can send up to ((message limit)) messages per year.",
       "",
       "",
       "As a live service, you’ll need to know who to contact if you have a question, or something goes wrong.",


### PR DESCRIPTION
https://github.com/GSA/notifications-utils/issues/85

Related: https://github.com/GSA/notifications-admin/pull/951

![image](https://github.com/GSA/notifications-api/assets/53159604/d7c9ad3b-02c7-478d-9305-3addac2244d4)


I changed "day" to year" for email template and app UI 