### PR TITLE
Make the invite link a button instead of a long ugly link#863

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -22,7 +22,7 @@
       "",
       "Click this link to create an account on Notify.gov:",
       "",
-      "((url))",
+      "[Join Service] ((url))",
       "",
       "",
       "This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure."

--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -83,7 +83,7 @@
       "To complete your registration for Notify.gov please click the link below",
       "",
       "",
-      "((url))"
+      "[Join Service] ((url))"
     ]
   },
   {


### PR DESCRIPTION
https://github.com/orgs/GSA/projects/20/views/1?pane=issue&itemId=41367752

This task is to add in "Join Service" to the long link. 

Before
![image](https://github.com/GSA/notifications-api/assets/53159604/49b17a6c-0169-4ef4-af28-2a5af3cde279)

After
![image](https://github.com/GSA/notifications-api/assets/53159604/3de04631-34fe-4975-a8dd-e337d97acd50)
