### PR TITLE
notify-admin-931 fix timezone again via migration

### DIFF
--- a/migrations/versions/0408_fix_timezone_again.py
+++ b/migrations/versions/0408_fix_timezone_again.py
@@ -1,0 +1,18 @@
+"""
+
+Revises: 0407_fix_preferred_timezone
+
+"""
+from alembic import op
+
+down_revision = "0407_fix_preferred_timezone"
+revision = "0408_fix_timezone_again"
+
+
+def upgrade():
+    op.execute("update users set preferred_timezone='US/Eastern' where (preferred_timezone='') is not false")
+
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
We need to check for nulls in the preferred_timezone_column as well.