### PR TITLE
Remove unused variable

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -261,8 +261,7 @@ def update_service(service_id):
             service_id=service_id,
             template_id=current_app.config["SERVICE_NOW_LIVE_TEMPLATE_ID"],
             personalisation={
-                "service_name": current_data["name"],
-                "message_limit": "{:,}".format(current_data["message_limit"]),
+                "service_name": current_data["name"]
             },
             include_user_fields=["name"],
         )


### PR DESCRIPTION
This changeset follows up PR #636 to remove a variable no longer used in the go live email template.

## Security Considerations

- None for this change.