### PR TITLE
Join Service: Bug fix - added extra parentheses

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -22,7 +22,7 @@
       "",
       "Click this link to create an account on Notify.gov:",
       "",
-      "[Join Service](url)",
+      "[Join Service](((url)))",
       "",
       "",
       "This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure."
@@ -83,7 +83,7 @@
       "To complete your registration for Notify.gov please click the link below",
       "",
       "",
-      "[Join Service](url)"
+      "[Join Service](((url)))"
     ]
   },
   {


### PR DESCRIPTION
I found a bug. 

Use `[Join Service](((url)))` with the extra parentheses, otherwise the url link does not work. 

![Image](https://github.com/GSA/notifications-admin/assets/53159604/5a4a0923-ef02-4f51-9836-b9141bf75643)