### PR TITLE
Api 683 make UI and reports reflect opt out numbers

### DIFF
--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -127,7 +127,7 @@ class AwsCloudwatchClient(Client):
             return (
                 "failure",
                 message["delivery"]["providerResponse"],
-                message["delivery"]["phoneCarrier"],
+                message["delivery"].get("phoneCarrier", "Unknown Carrier"),
             )
 
         if time_now > (created_at + timedelta(hours=3)):

--- a/migrations/versions/0409_fix_service_name.py
+++ b/migrations/versions/0409_fix_service_name.py
@@ -27,7 +27,8 @@ def upgrade():
     # select_by_val = service_id
     input_params = {"service_id": service_id}
     conn.execute(
-        text("update services set name='Notify.gov' where id =:service_id"), input_params
+        text("update services set name='Notify.gov' where id =:service_id"),
+        input_params,
     )
 
     # table_name = 'services_history'


### PR DESCRIPTION
There was an error deep in the code where "phoneCarrier" was not found in a particular structure, for opt-outs. The fix was to make it default to "Unknown Carrier" if this situation happens when making the error response, fixing the bug and making it now track opt outs correctly.

Issue: #683 