### PR TITLE
Clean up client classes

### DIFF
--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -1,3 +1,5 @@
+from typing import Protocol
+
 from botocore.config import Config
 
 AWS_CLIENT_CONFIG = Config(
@@ -22,7 +24,7 @@ class ClientException(Exception):
     pass
 
 
-class Client(object):
+class Client(Protocol):
     """
     Base client for sending notifications.
     """

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Protocol
 
 from botocore.config import Config
@@ -29,7 +30,9 @@ class Client(Protocol):
     Base client for sending notifications.
     """
 
-    pass
+    @abstractmethod
+    def init_app(self, current_app, *args, **kwargs):
+        raise NotImplementedError("TODO: Need to implement.")
 
 
 class NotificationProviderClients(object):

--- a/app/clients/email/__init__.py
+++ b/app/clients/email/__init__.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod, abstractproperty
+
 from app.clients import Client, ClientException
 
 
@@ -27,9 +29,10 @@ class EmailClient(Client):
     Base Email client for sending emails.
     """
 
+    @abstractmethod
     def send_email(self, *args, **kwargs):
         raise NotImplementedError("TODO Need to implement.")
 
-    @property
+    @abstractproperty
     def name(self):
         raise NotImplementedError("TODO Need to implement.")

--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -10,7 +10,7 @@ class PerformancePlatformClient:
     def active(self):
         return self._active
 
-    def init_app(self, app):
+    def init_app(self, app, *args, **kwargs):
         self._active = app.config.get("PERFORMANCE_PLATFORM_ENABLED")
         if self.active:
             self.performance_platform_url = app.config.get("PERFORMANCE_PLATFORM_URL")

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 from app.clients import Client, ClientException
 
 
@@ -18,11 +20,14 @@ class SmsClient(Client):
     Base Sms client for sending smss.
     """
 
+    @abstractmethod
     def init_app(self, *args, **kwargs):
         raise NotImplementedError("TODO Need to implement.")
 
+    @abstractmethod
     def send_sms(self, *args, **kwargs):
         raise NotImplementedError("TODO Need to implement.")
 
+    @abstractmethod
     def get_name(self):
         raise NotImplementedError("TODO Need to implement.")

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -13,7 +13,7 @@ class SmsClientResponseException(ClientException):
         self.message = message
 
     def __str__(self):
-        return "Message {}".format(self.message)
+        return f"Message {self.message}"
 
 
 class SmsClient(Client):

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -1,4 +1,5 @@
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
+from typing import final
 
 from app.clients import Client, ClientException
 
@@ -21,13 +22,13 @@ class SmsClient(Client):
     """
 
     @abstractmethod
-    def init_app(self, *args, **kwargs):
-        raise NotImplementedError("TODO Need to implement.")
-
-    @abstractmethod
     def send_sms(self, *args, **kwargs):
         raise NotImplementedError("TODO Need to implement.")
 
-    @abstractmethod
-    def get_name(self):
+    @abstractproperty
+    def name(self):
         raise NotImplementedError("TODO Need to implement.")
+
+    @final
+    def get_name(self):
+        return self.name

--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -43,9 +43,6 @@ class AwsSnsClient(SmsClient):
     def name(self):
         return "sns"
 
-    def get_name(self):
-        return self.name
-
     def _valid_sender_number(self, sender):
         return sender and re.match(self._valid_sender_regex, sender)
 

--- a/migrations/versions/0409_fix_service_name.py
+++ b/migrations/versions/0409_fix_service_name.py
@@ -27,7 +27,8 @@ def upgrade():
     # select_by_val = service_id
     input_params = {"service_id": service_id}
     conn.execute(
-        text("update services set name='Notify.gov' where id =:service_id"), input_params
+        text("update services set name='Notify.gov' where id =:service_id"),
+        input_params,
     )
 
     # table_name = 'services_history'

--- a/tests/app/clients/test_sms.py
+++ b/tests/app/clients/test_sms.py
@@ -10,6 +10,12 @@ def fake_client(notify_api):
         def name(self):
             return "fake"
 
+        def init_app(self, current_app, *args, **kwargs):
+            pass
+
+        def send_sms(self, *args, **kwargs):
+            pass
+
     fake_client = FakeSmsClient()
     # fake_client.init_app(notify_api)
     return fake_client


### PR DESCRIPTION
I did a little refactoring/adjusting to the method the clients are implemented, to use some more future-proof Python features:

1. The "interface" classes that existed are now all Protocols. This will allow for eventual inclusion of modern Python techniques like type hinting, allowing for both static and runtime checking of attributes.
2. All of the methods with a `raise NotImplementedError` have been decorated with `@abstractmethod` or `@abstractproperty` as applies. This will ensure that any class derived from these must implement those methods in order to run.
3. The `init_app()` method was existing in all of the concrete implementations of a client. As such, I factored it into being part of the base `Client` Protocol. There are other methods that I believe could also be moved to here (like the `name` property, or the `get_name()` method) but I left them alone for now.
4. The tests had to be adjusted a little to handle the new requirements enforced with `@abstractmethod` and `@abstractproperty`.

Note: The `PerformancePlatformClient` does not explicitly extend the `Client` base class, but it does seem to follow the pattern for the protocol it represents. This is completely OK with Python's Protocol structure, as long as it has all the methods which are defined for the Client base class within it, and it still can be used with the protocol type.