### PR TITLE
Mirror Admin REDIS_ENABLED config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,6 @@ jobs:
         NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
         NOTIFY_E2E_TEST_EMAIL: ${{ secrets.NOTIFY_E2E_TEST_EMAIL }}
         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
-        REDIS_ENABLED: 1
       with:
         cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
@@ -76,7 +75,6 @@ jobs:
           --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
           --var NOTIFY_E2E_TEST_EMAIL="$NOTIFY_E2E_TEST_EMAIL"
           --var NOTIFY_E2E_TEST_PASSWORD="$NOTIFY_E2E_TEST_PASSWORD"
-          --var REDIS_ENABLED="$REDIS_ENABLED"
 
     - name: Check for changes to egress config
       id: changed-egress-config

--- a/deploy-config/demo.yml
+++ b/deploy-config/demo.yml
@@ -6,4 +6,5 @@ worker_memory: 512M
 scheduler_memory: 256M
 public_api_route: notify-api-demo.app.cloud.gov
 admin_base_url: https://notify-demo.app.cloud.gov
+redis_enabled: 1
 default_toll_free_number: "+18337581259"

--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -6,4 +6,5 @@ worker_memory: 512M
 scheduler_memory: 256M
 public_api_route: notify-api.app.cloud.gov
 admin_base_url: https://beta.notify.gov
+redis_enabled: 1
 default_toll_free_number: "+18447952263"

--- a/deploy-config/sandbox.yml
+++ b/deploy-config/sandbox.yml
@@ -6,6 +6,7 @@ worker_memory: 512M
 scheduler_memory: 256M
 public_api_route: notify-api-sandbox.app.cloud.gov
 admin_base_url: https://notify-sandbox.app.cloud.gov
+redis_enabled: 1
 default_toll_free_number: "+18885989205"
 ADMIN_CLIENT_SECRET: sandbox-notify-secret-key
 DANGEROUS_SALT: sandbox-notify-salt

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -6,4 +6,5 @@ worker_memory: 512M
 scheduler_memory: 256M
 public_api_route: notify-api-staging.app.cloud.gov
 admin_base_url: https://notify-staging.app.cloud.gov
+redis_enabled: 1
 default_toll_free_number: "+18556438890"


### PR DESCRIPTION
This changeset adjusts the REDIS_ENABLED environment variable to match how the admin app is set up to make sure the API properly connects to the Redis service.

The previous change didn't surface the environment variable fully, unfortunately.

## Security Considerations

- The API isn't currently talking to the Redis service in the cloud.gov environment.