### PR TITLE
Really make sure Redis is enabled

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,7 +89,7 @@ class Config(object):
     PAGE_SIZE = 50
     API_PAGE_SIZE = 250
     REDIS_URL = cloud_config.redis_url
-    REDIS_ENABLED = getenv("REDIS_ENABLED", "0") == "1"
+    REDIS_ENABLED = getenv("REDIS_ENABLED", "1") == "1"
     EXPIRE_CACHE_TEN_MINUTES = 600
     EXPIRE_CACHE_EIGHT_DAYS = 8 * 24 * 60 * 60
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -40,6 +40,7 @@ applications:
       NEW_RELIC_ENVIRONMENT: ((env))
       NEW_RELIC_LICENSE_KEY: ((NEW_RELIC_LICENSE_KEY))
 
+      REDIS_ENABLED: ((redis_enabled))
       NOTIFY_ENVIRONMENT: ((env))
       API_HOST_NAME: https://((public_api_route))
       ADMIN_BASE_URL: ((admin_base_url))


### PR DESCRIPTION
This changeset should cover the rest of the missing pieces to make sure Redis connectivity is truly established in the API app.

## Security Considerations

- The Redis service was still not connecting to the API app in the cloud.gov environment.