### PR TITLE
fix redis issue causing error in log

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -112,9 +112,11 @@ def check_db_notification_fails():
     on a breach.  I.e., if the last number was at 23% and the current number is 27%, send an email.
     But if the last number was 26% and the current is 27%, don't.
     """
-    last_value = redis_store.get("LAST_DB_NOTIFICATION_COUNT").decode("utf-8")
+    last_value = redis_store.get("LAST_DB_NOTIFICATION_COUNT")
     if not last_value:
         last_value = 0
+    else:
+        last_value = int(last_value.decode("utf-8"))
 
     failed_count = dao_get_failed_notification_count()
     if failed_count > last_value:

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -98,6 +98,8 @@ def expire_or_delete_invitations():
         raise
 
 
+# TODO THIS IS ACTUALLY DEPRECATED, WE ARE REMOVING PHONE NUMBERS FROM THE DB
+# SO THERE WILL BE NO REASON TO KEEP TRACK OF THIS COUNT
 @notify_celery.task(name="check-db-notification-fails")
 def check_db_notification_fails():
     """
@@ -110,7 +112,7 @@ def check_db_notification_fails():
     on a breach.  I.e., if the last number was at 23% and the current number is 27%, send an email.
     But if the last number was 26% and the current is 27%, don't.
     """
-    last_value = redis_store.get("LAST_DB_NOTIFICATION_COUNT")
+    last_value = redis_store.get("LAST_DB_NOTIFICATION_COUNT").decode("utf-8")
     if not last_value:
         last_value = 0
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -72,6 +72,8 @@ def test_should_check_db_notification_fails_task_less_than_25_percent(
     mock_dao = mocker.patch(
         "app.celery.scheduled_tasks.dao_get_failed_notification_count"
     )
+    mock_redis = mocker.patch("app.celery.scheduled_tasks.redis_store")
+    mock_redis.get.return_value = 0
     mock_provider = mocker.patch("app.celery.scheduled_tasks.provider_to_use")
     mock_dao.return_value = 10
     check_db_notification_fails()
@@ -88,13 +90,13 @@ def test_should_check_db_notification_fails_task_over_50_percent(
         "app.celery.scheduled_tasks.dao_get_failed_notification_count"
     )
     mock_provider = mocker.patch("app.celery.scheduled_tasks.provider_to_use")
-    mock_redis = mocker.patch("app.celery.scheduled_tasks.redis_store.get")
+    mock_redis = mocker.patch("app.celery.scheduled_tasks.redis_store")
     mock_dao.return_value = 5001
-    mock_redis.return_value = 0
+    mock_redis.get.return_value = "0".encode("utf-8")
     check_db_notification_fails()
     assert mock_provider.call_count == 1
 
-    mock_redis.return_value = 5001
+    mock_redis.get.return_value = "5001".encode("utf-8")
     check_db_notification_fails()
     assert mock_provider.call_count == 1
 


### PR DESCRIPTION
1.  We origin added an alert that would send an email when the number of failed notifications being kept in the notification table went above a certain level:  2500, 5000, 7500, 9000, etc.
2. This alert was going to use redis to keep track of the last value for the level of failures, and was assumed to be working
3. But actually redis was not working at all on staging
4. Now that redis is working, there is an error because "last_value" comes back from redis_store.get() by default as bytes and we were not decoding it down to a string.

So this PR fixes the new error that appears in the logs, but is not terribly important. Once we remove the phone numbers from the database, this alert will go away as well.