### PR TITLE
Update try/except block to catch Exception

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -76,7 +76,7 @@ def send_sms_to_provider(notification):
                         notification.job_id,
                         notification.job_row_number,
                     )
-                except BaseException:
+                except Exception:
                     # It is our 2facode, maybe
                     key = f"2facode-{notification.id}".replace(" ", "")
                     recipient = redis_store.raw_get(key)


### PR DESCRIPTION
This changeset updates a try/except block to catch `Exception` instead of `BaseException`.  Using BaseException is an anti-pattern and [is not intended for user-defined code](https://docs.python.org/3.9/library/exceptions.html#BaseException); it can also lead to other unintended side effects if not handled properly.

This is enough of a concern that the new release of `flake8-bugbear` now issues warnings when it sees `BaseException` being caught without an immediate re-raise (see issue https://github.com/PyCQA/flake8-bugbear/issues/174 for more details).