### PR TITLE
Adding missing egress proxy configuration

### DIFF
--- a/.profile
+++ b/.profile
@@ -3,5 +3,6 @@
 # https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#profile
 ##
 
+export http_proxy=$egress_proxy
 export https_proxy=$egress_proxy
 export NEW_RELIC_PROXY_HOST=$egress_proxy

--- a/deploy-config/egress_proxy/notify-api-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-demo.allow.acl
@@ -8,3 +8,5 @@ s3-fips.us-west-2.amazonaws.com
 sns-fips.us-east-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-demo.apps.internal
+idp.int.identitysandbox.gov
+secure.login.gov

--- a/deploy-config/egress_proxy/notify-api-production.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-production.allow.acl
@@ -7,3 +7,5 @@ s3-fips.us-gov-west-1.amazonaws.com
 sns.us-gov-west-1.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-production.apps.internal
+idp.int.identitysandbox.gov
+secure.login.gov

--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -8,3 +8,5 @@ s3-fips.us-west-2.amazonaws.com
 sns-fips.us-west-2.amazonaws.com
 gov-collector.newrelic.com
 egress-proxy-notify-api-staging.apps.internal
+idp.int.identitysandbox.gov
+secure.login.gov


### PR DESCRIPTION
This changeset adds a missing egress proxy configuration environment variable.

This change is based on the [cg-egress-proxy deployment instructions](https://github.com/gsa-tts/cg-egress-proxy?tab=readme-ov-file#deploying-the-proxy-by-hand).

It also adds the Login.gov URLs to our egress allow ACLs.

## Security Considerations

- This will ensure that our application is correctly interacting with the egress proxy we have configured to restrict traffic.