### PR TITLE
Package del/fai/pen counts

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -20,6 +20,7 @@ from app.models import (
     EMAIL_TYPE,
     KEY_TYPE_TEST,
     NOTIFICATION_CREATED,
+    NOTIFICATION_DELIVERED,
     NOTIFICATION_FAILED,
     NOTIFICATION_PENDING,
     NOTIFICATION_PENDING_VIRUS_CHECK,
@@ -211,6 +212,33 @@ def dao_get_notification_count_for_service(*, service_id):
 def dao_get_failed_notification_count():
     failed_count = Notification.query.filter_by(status=NOTIFICATION_FAILED).count()
     return failed_count
+
+
+def get_service_failed_count(service_id):
+    failed_count = Notification.query.filter_by(
+        service_id=service_id,
+        status=NOTIFICATION_FAILED,
+        created_at=datetime.utcnow() - timedelta(days=7),
+    ).count()
+    return failed_count
+
+
+def get_service_delivered_count(service_id):
+    delivered_count = Notification.query.filter_by(
+        service_id=service_id,
+        status=NOTIFICATION_DELIVERED,
+        created_at=datetime.utcnow() - timedelta(days=7),
+    ).count()
+    return delivered_count
+
+
+def get_service_pending_count(service_id):
+    pending_count = Notification.query.filter_by(
+        service_id=service_id,
+        status=NOTIFICATION_PENDING,
+        created_at=datetime.utcnow() - timedelta(days=7),
+    ).count()
+    return pending_count
 
 
 def get_notification_with_personalisation(service_id, notification_id, key_type):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -26,7 +26,7 @@ from app.dao.fact_notification_status_dao import (
     fetch_stats_for_all_services_by_date_range,
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
-from app.dao.notifications_dao import dao_get_notification_count_for_service
+from app.dao.notifications_dao import dao_get_notification_count_for_service, get_service_delivered_count, get_service_failed_count, get_service_pending_count
 from app.dao.organization_dao import dao_get_organization_by_service_id
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,
@@ -74,7 +74,12 @@ from app.dao.services_dao import (
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
-from app.models import KEY_TYPE_NORMAL, EmailBranding, Permission, Service
+from app.models import (
+    KEY_TYPE_NORMAL,
+    EmailBranding,
+    Permission,
+    Service,
+)
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
@@ -193,8 +198,13 @@ def get_service_by_id(service_id):
         )
     else:
         fetched = dao_fetch_service_by_id(service_id)
-
+        failed_count = get_service_failed_count(service_id)
+        delivered_count = get_service_delivered_count(service_id)
+        pending_count = get_service_pending_count(service_id)
         data = service_schema.dump(fetched)
+        data["failed_count"] = failed_count
+        data["delivered_count"] = delivered_count
+        data["pending_count"] = pending_count
     return jsonify(data=data)
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -26,7 +26,12 @@ from app.dao.fact_notification_status_dao import (
     fetch_stats_for_all_services_by_date_range,
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
-from app.dao.notifications_dao import dao_get_notification_count_for_service, get_service_delivered_count, get_service_failed_count, get_service_pending_count
+from app.dao.notifications_dao import (
+    dao_get_notification_count_for_service,
+    get_service_delivered_count,
+    get_service_failed_count,
+    get_service_pending_count,
+)
 from app.dao.organization_dao import dao_get_organization_by_service_id
 from app.dao.service_data_retention_dao import (
     fetch_service_data_retention,

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -79,12 +79,7 @@ from app.dao.services_dao import (
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import get_user_by_id
 from app.errors import InvalidRequest, register_errors
-from app.models import (
-    KEY_TYPE_NORMAL,
-    EmailBranding,
-    Permission,
-    Service,
-)
+from app.models import KEY_TYPE_NORMAL, EmailBranding, Permission, Service
 from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -223,7 +223,13 @@ def test_get_live_services_data(sample_user, admin_request):
     ]
 
 
-def test_get_service_by_id(admin_request, sample_service):
+def test_get_service_by_id(admin_request, sample_service, mocker):
+    delivered_count = mocker.patch("app.service.rest.get_service_delivered_count")
+    delivered_count.return_value = 7
+    failed_count = mocker.patch("app.service.rest.get_service_failed_count")
+    failed_count.return_value = 6
+    pending_count = mocker.patch("app.service.rest.get_service_pending_count")
+    pending_count.return_value = 5
     json_resp = admin_request.get(
         "service.get_service_by_id", service_id=sample_service.id
     )
@@ -231,6 +237,9 @@ def test_get_service_by_id(admin_request, sample_service):
     assert json_resp["data"]["id"] == str(sample_service.id)
     assert json_resp["data"]["email_branding"] is None
     assert json_resp["data"]["prefix_sms"] is True
+    assert json_resp["data"]["delivered_count"] == 7
+    assert json_resp["data"]["failed_count"] == 6
+    assert json_resp["data"]["pending_count"] == 5
 
     assert set(json_resp["data"].keys()) == {
         "active",
@@ -261,6 +270,9 @@ def test_get_service_by_id(admin_request, sample_service):
         "service_callback_api",
         "volume_email",
         "volume_sms",
+        "delivered_count",
+        "failed_count",
+        "pending_count",
     }
 
 


### PR DESCRIPTION
Added helper methods in `notifications_dao.py` to retrieve counts for `pending`, `failed`, and `delivered`.

Fixed tests with appropriate mocks in `test_get_service_by_id()`.