### PR TITLE
API:  Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,12 @@ expected outcome(s) is/are from there.  If there are complex implementation
 details within the changes, this is a great place to explain those details using
 plain language.
 
+This should include:
+
+- Links to issues that this PR addresses
+- Screenshots of any visible changes
+- Dependency changes
+
 If there are any caveats, known issues, follow-up items, etc., make a quick note
 of them here as well, though more details are probably warranted in the issue
 itself in this case.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ have all of the relevant details needed for our work.
 At the minimum, please be sure to fill in all sections found below and also do
 the following:
 
+- Provide an appropriate and descriptive title for the pull request
 - Link the pull request to its corresponding issue (must be done after creating
   the pull request itself)
 - Assign yourself as the author
@@ -13,12 +14,16 @@ the following:
 - Select one or more reviewers from the team or mark the pull request as a draft
   depending on its current state
    - If the pull request is a draft, please be sure to add reviewers once it is
-     ready for review
+     ready for review and mark it ready for review
 
-For each section, please delete the instructions/sample (text that includes this
+For each section, please delete the instructions/sample text (that includes this
 text, though it is wrapped in an HTML comment just in case) and put in your own
 information.  Thank you!
 -->
+
+*A note to PR reviewers: it may be helpful to review our
+[code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews)
+to know what to keep in mind while reviewing pull requests.*
 
 ## Description
 
@@ -30,7 +35,7 @@ plain language.
 This should include:
 
 - Links to issues that this PR addresses
-- Screenshots of any visible changes
+- Screenshots or screen captures of any visible changes, especially for UI work
 - Dependency changes
 
 If there are any caveats, known issues, follow-up items, etc., make a quick note
@@ -64,7 +69,7 @@ Relevant details could include (and are not limited to) the following:
 - Handling of any sensitive information, such as PII
 - Handling of information within log statements or other application monitoring
   services/hooks
-- The inclusion of a new external dependency
+- The inclusion of a new external dependency or the removal of an existing one
 - ... (anything else relevant from a security compliance perspective)
 
 There are some cases where there are no security considerations to be had, e.g.,

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,68 @@
+<!--
+Please follow the instructions found in this pull request template so that we
+have all of the relevant details needed for our work.
+
+At the minimum, please be sure to fill in all sections found below and also do
+the following:
+
+- Link the pull request to its corresponding issue (must be done after creating
+  the pull request itself)
+- Assign yourself as the author
+- Attach the appropriate labels to it
+- Set it to be on the Notify.gov project board
+- Select one or more reviewers from the team or mark the pull request as a draft
+  depending on its current state
+   - If the pull request is a draft, please be sure to add reviewers once it is
+     ready for review
+
+For each section, please delete the instructions/sample (text that includes this
+text, though it is wrapped in an HTML comment just in case) and put in your own
+information.  Thank you!
+-->
+
+## Description
+
+Please enter a clear description about your proposed changes and what the
+expected outcome(s) is/are from there.  If there are complex implementation
+details within the changes, this is a great place to explain those details using
+plain language.
+
+If there are any caveats, known issues, follow-up items, etc., make a quick note
+of them here as well, though more details are probably warranted in the issue
+itself in this case.
+
+## TODO (optional)
+
+If you're opening a draft PR, it might be helpful to list any outstanding work,
+especially if you're asking folks to take a look before it's ready for full
+review.  In this case, create a small checklist with the outstanding items:
+
+- [ ] TODO item 1
+- [ ] TODO item 2
+- [ ] TODO item ...
+
+## Security Considerations
+
+Please think about the security compliance aspect of your changes and what the
+potential impacts might be.
+
+**NOTE:  Please be mindful of sharing sensitive information here!  If you're not
+sure of what to write, please ask the team first before writing anything here.**
+
+Relevant details could include (and are not limited to) the following:
+
+- Handling secrets/credential management (or specifically calling out that there
+  is nothing to handle)
+- Any adjustments to the flow of data in and out the system, or even within it
+- Connecting or disconnecting any external services to the application
+- Handling of any sensitive information, such as PII
+- Handling of information within log statements or other application monitoring
+  services/hooks
+- The inclusion of a new external dependency
+- ... (anything else relevant from a security compliance perspective)
+
+There are some cases where there are no security considerations to be had, e.g.,
+updating our documentation with publicly available information.  In those cases
+it is fine to simply put something like this:
+
+- None; this is a documentation update with publicly available information.


### PR DESCRIPTION
This changeset adds a template to the repository for our pull requests.  The intention is two-fold:

- To make it easier to know what information and details to include in our pull requests
- To improve the quality and usefulness of our pull requests

This is a start and we will be adjusting this over time as we learn more and refine our process.

## Security Considerations

- This will help make sure we capture relevant information and details from a security compliance perspective in future pull requests.