### PR TITLE
Returned months changed to calendar year

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -3,11 +3,7 @@ from datetime import date, datetime, time, timedelta
 
 def get_months_for_financial_year(year):
     return [
-        month
-        for month in (
-            get_months_for_year(4, 13, year) + get_months_for_year(1, 4, year + 1)
-        )
-        if month < datetime.now()
+        month for month in (get_months_for_year(1, 13, year)) if month < datetime.now()
     ]
 
 

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -149,10 +149,13 @@ def _stats(requested, delivered, failed):
 @pytest.mark.parametrize(
     "year, expected_years",
     [
-        (2018, ["2018-04", "2018-05", "2018-06"]),
+        (2018, ["2018-01", "2018-02", "2018-03", "2018-04", "2018-05", "2018-06"]),
         (
             2017,
             [
+                "2017-01",
+                "2017-02",
+                "2017-03",
                 "2017-04",
                 "2017-05",
                 "2017-06",
@@ -162,9 +165,6 @@ def _stats(requested, delivered, failed):
                 "2017-10",
                 "2017-11",
                 "2017-12",
-                "2018-01",
-                "2018-02",
-                "2018-03",
             ],
         ),
     ],
@@ -220,8 +220,11 @@ def test_add_monthly_notification_status_stats():
     data["2018-05"]["sms"]["sending"] = 16
 
     add_monthly_notification_status_stats(data, rows)
-
+    # first 3 months are empty
     assert data == {
+        "2018-01": {"sms": {}, "email": {}},
+        "2018-02": {"sms": {}, "email": {}},
+        "2018-03": {"sms": {}, "email": {}},
         "2018-04": {"sms": {"sending": 1, "delivered": 2}, "email": {"sending": 4}},
         "2018-05": {"sms": {"sending": 24}, "email": {"sending": 32}},
         "2018-06": {"sms": {}, "email": {}},

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -177,6 +177,9 @@ def test_get_monthly_notification_stats_returns_empty_stats_with_correct_dates(
     assert len(response["data"]) == 12
 
     keys = [
+        "2016-01",
+        "2016-02",
+        "2016-03",
         "2016-04",
         "2016-05",
         "2016-06",
@@ -186,9 +189,6 @@ def test_get_monthly_notification_stats_returns_empty_stats_with_correct_dates(
         "2016-10",
         "2016-11",
         "2016-12",
-        "2017-01",
-        "2017-02",
-        "2017-03",
     ]
     assert sorted(response["data"].keys()) == keys
     for val in response["data"].values():
@@ -266,7 +266,7 @@ def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(
         year=2016,
     )
 
-    assert len(response["data"]) == 3  # apr, may, jun
+    assert len(response["data"]) == 6  # January to June
     assert response["data"]["2016-05"] == {"sms": {"delivered": 1}, "email": {}}
     assert response["data"]["2016-06"] == {
         "sms": {


### PR DESCRIPTION
## Description

Changed logic in `get_months_for_financial_year(year)` to return the months before `now` like a calendar year instead of the logic that was in place for the UK's financial year.

## TODO

None

## Security Considerations

None