### PR TITLE
Removed gov.uk text from org invite

### DIFF
--- a/app/organization/invite_rest.py
+++ b/app/organization/invite_rest.py
@@ -55,7 +55,7 @@ def invite_user_to_org(organization_id):
         service=template.service,
         personalisation={
             "user_name": (
-                "The GOV.UK Notify team"
+                "The Notify.gov team"
                 if invited_org_user.invited_by.platform_admin
                 else invited_org_user.invited_by.name
             ),

--- a/tests/app/organization/test_invite_rest.py
+++ b/tests/app/organization/test_invite_rest.py
@@ -13,7 +13,7 @@ from tests.app.db import create_invited_org_user
 
 @pytest.mark.parametrize(
     "platform_admin, expected_invited_by",
-    ((True, "The GOV.UK Notify team"), (False, "Test User")),
+    ((True, "The Notify.gov team"), (False, "Test User")),
 )
 @pytest.mark.parametrize(
     "extra_args, expected_start_of_invite_url",


### PR DESCRIPTION
## Description

This PR addresses the issue found on staging, when inviting a user through the organization invite path the email has personalisation saying "The GOV.uk team...". It's a hardcoded string so it will now say Notify.gov team.

<img width="590" alt="Screen Shot 2024-03-04 at 10 05 10 AM" src="https://github.com/GSA/notifications-api/assets/90117200/b1a4dd7e-0c3e-4854-bfe2-27741904b5a8">


## TODO (optional)

My only question is what do we want the email to say if not "Notify.gov team"?

## Security Considerations

None
