### PR TITLE
fix login.gov to use user uuid instead of email (notify-admin-1277)

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -25,6 +25,32 @@ def create_secret_code(length=6):
     return "{:0{length}d}".format(random_number, length=length)
 
 
+def get_login_gov_user(login_uuid, email_address):
+    """
+    We want to check to see if the user is registered with login.gov
+    If we can find the login.gov uuid in our user table, then they are.
+
+    Also, because we originally keyed off email address we might have a few
+    older users who registered with login.gov but we don't know what their
+    login.gov uuids are.  Eventually the code that checks by email address
+    should be removed.
+    """
+
+    print(User.query.filter_by(login_uuid=login_uuid).first())
+    user = User.query.filter_by(login_uuid=login_uuid).first()
+    if user:
+        if user.email_address != email_address:
+            save_user_attribute(user, {"email_address": email_address})
+        return user
+    # Remove this 1 July 2025, all users should have login.gov uuids by now
+    user = User.query.filter_by(email_address=email_address).first()
+    if user:
+        save_user_attribute(user, {"login_uuid": login_uuid})
+        return user
+
+    return None
+
+
 def save_user_attribute(usr, update_dict=None):
     db.session.query(User).filter_by(id=usr.id).update(update_dict or {})
     db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -109,6 +109,7 @@ class User(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String, nullable=False, index=True, unique=False)
     email_address = db.Column(db.String(255), nullable=False, index=True, unique=True)
+    login_uuid = db.Column(db.Text, nullable=True, index=True, unique=True)
     created_at = db.Column(
         db.DateTime,
         index=False,

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -19,6 +19,7 @@ from app.dao.users_dao import (
     create_secret_code,
     create_user_code,
     dao_archive_user,
+    get_login_gov_user,
     get_user_and_accounts,
     get_user_by_email,
     get_user_by_id,
@@ -526,6 +527,16 @@ def set_permissions(user_id, service_id):
         dao_update_service_user(service_user)
 
     return jsonify({}), 204
+
+
+@user_blueprint.route("/get-login-gov-user", methods=["POST"])
+def get_user_login_gov_user():
+    request_args = request.get_json()
+    login_uuid = request_args["login_uuid"]
+    email = request_args["email"]
+    user = get_login_gov_user(login_uuid, email)
+    result = user.serialize()
+    return jsonify(data=result)
 
 
 @user_blueprint.route("/email", methods=["POST"])

--- a/migrations/versions/0411_add_login_uuid.py
+++ b/migrations/versions/0411_add_login_uuid.py
@@ -1,0 +1,20 @@
+"""
+
+Revision ID: 0411_add_login_uuid
+Revises: 410_enums_for_everything
+Create Date: 2023-04-24 11:35:22.873930
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0411_add_login_uuid"
+down_revision = "0410_enums_for_everything"
+
+
+def upgrade():
+    op.add_column("users", sa.Column("login_uuid", sa.Text))
+
+
+def downgrade():
+    op.drop_column("users", "login_uuid")

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -15,6 +15,7 @@ from app.dao.users_dao import (
     dao_archive_user,
     delete_codes_older_created_more_than_a_day_ago,
     delete_model_user,
+    get_login_gov_user,
     get_user_by_email,
     get_user_by_id,
     increment_failed_login_count,
@@ -108,6 +109,12 @@ def test_reset_failed_login_should_set_failed_logins_to_0(sample_user):
 def test_get_user_by_email(sample_user):
     user_from_db = get_user_by_email(sample_user.email_address)
     assert sample_user == user_from_db
+
+
+def test_get_login_gov_user(sample_user):
+    user_from_db = get_login_gov_user("fake_login_gov_uuid", sample_user.email_address)
+    assert sample_user.email_address == user_from_db.email_address
+    assert user_from_db.login_uuid is not None
 
 
 def test_get_user_by_email_is_case_insensitive(sample_user):


### PR DESCRIPTION

## Description

Our original implementation of the login.gov integration was keyed off the user's email address.  While this works, it's not best practice because if the user were to change their email address in the login.gov app, we would lose track of said user and they would not be able to log in.

Best practice is to use login.gov's UUIDs for users.  That way if the user changes their email address in login.gov, they can still log into our app.

## TODO

- [ ] TODO Check in the matching PR in admin at the same time

## Security Considerations

It's important not to leak info through debug statements.