### PR TITLE
fix code coverage reporting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,7 +61,8 @@ jobs:
         NOTIFY_E2E_TEST_HTTP_AUTH_USER: ${{ secrets.NOTIFY_E2E_TEST_HTTP_AUTH_USER }}
         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
     - name: Check coverage threshold
-      run: poetry run coverage report --fail-under=50
+      # TODO get this back up to 95
+      run: poetry run coverage report --fail-under=87
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test: ## Run tests and create coverage report
 	poetry run black .
 	poetry run flake8 .
 	poetry run isort --check-only ./app ./tests
-	poetry run coverage run -m pytest -vv --maxfail=10
+	poetry run coverage run --omit=*/notifications_utils/* -m pytest --maxfail=10
 	poetry run coverage report -m --fail-under=95
 	poetry run coverage html -d .coverage_cache
 


### PR DESCRIPTION
## Description

Local testing has been failing for a while because code coverage was below 95% (it was being reported as 93%).

It turns out there are two big discrepancies between local code coverage testing and testing in the cloud.

In the cloud, coverage failed if it was below 50%.  Coverage also EXCLUDED notifications-utils code.

Locally, coverage failed if it was below 95%, but it INCLUDED notifications-utils code.

If we exclude notifications-utils code, the true test coverage is 88%.  So, set the fail threshold in the cloud temporarily to 87%, write a ticket to write more tests, and change the local coverage test to exclude notifications-utils while still failing if below 95%.

## TODO

- [ ] Write more tests to bring code coverage back up to 95%


## Security Considerations

N/A