### PR TITLE
[Bug] API-847 - Making the enum migration more smooth.

### DIFF
--- a/migrations/versions/0410_enums_for_everything.py
+++ b/migrations/versions/0410_enums_for_everything.py
@@ -468,6 +468,19 @@ def upgrade():
             existing_nullable=False,
             postgresql_using=enum_using("notification_type", NotificationType),
         )
+        # Clobbering bad data here. These are values we don't use any more, and anything with them is unnecessary.
+        op.execute("""
+            delete from
+                service_permissions
+            where
+                permission in (
+                    'letter',
+                    'letters_as_pdf',
+                    'upload_letters',
+                    'international_letters',
+                    'broadcast'
+                );
+        """)
         op.alter_column(
             "service_permissions",
             "permission",


### PR DESCRIPTION
This is an effort to correct an issue found in staging. It removes all records in the `service_permissions` table in the database that have invalid permission types assigned to them, right before switching to using the enum type. This should get us past the current blocking problem we're seeing in staging.

Reference: #847 