### PR TITLE
Fix reference to CF org vs. space

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -6,9 +6,8 @@ locals {
   delete_recursive_allowed = false
 }
 
-data "cloudfoundry_space" "demo" {
-  org_name = local.cf_org_name
-  name     = local.cf_space_name
+data "cloudfoundry_org" "org" {
+  name = local.cf_org_name
 }
 
 resource "cloudfoundry_space" "notify-demo" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -7,9 +7,8 @@ locals {
   allow_ssh                = false
 }
 
-data "cloudfoundry_space" "production" {
-  org_name = local.cf_org_name
-  name     = local.cf_space_name
+data "cloudfoundry_org" "org" {
+  name = local.cf_org_name
 }
 
 resource "cloudfoundry_space" "notify-production" {


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset fixes a reference to properly load the Cloud Foundry org for modifying the space. This is another part of https://github.com/GSA/notifications-api/issues/789

## Security Considerations

- None; just fixing how Terraform reads in the existing environment information.