### PR TITLE
fix email notifications missing personalisation (notify-api-853)

### DIFF
--- a/app/organization/rest.py
+++ b/app/organization/rest.py
@@ -1,6 +1,9 @@
+import json
+
 from flask import Blueprint, abort, current_app, jsonify, request
 from sqlalchemy.exc import IntegrityError
 
+from app import redis_store
 from app.config import QueueNames
 from app.dao.annual_billing_dao import set_default_free_allowance_for_service
 from app.dao.dao_utils import transaction
@@ -210,6 +213,12 @@ def send_notifications_on_mou_signed(organization_id):
             reply_to_text=notify_service.get_default_reply_to_email_address(),
         )
         saved_notification.personalisation = personalisation
+
+        redis_store.set(
+            f"email-personalisation-{saved_notification.id}",
+            json.dumps(personalisation),
+            ex=60 * 60,
+        )
         send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
     personalisation = {

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -140,6 +140,11 @@ def update_user_attribute(user_id):
         )
         saved_notification.personalisation = personalisation
 
+        redis_store.set(
+            f"email-personalisation-{saved_notification.id}",
+            json.dumps(personalisation),
+            ex=60 * 60,
+        )
         send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
     return jsonify(data=user_to_update.serialize()), 200
@@ -361,6 +366,12 @@ def create_2fa_code(
     # Assume that we never want to observe the Notify service's research mode
     # setting for this notification - we still need to be able to log into the
     # admin even if we're doing user research using this service:
+
+    redis_store.set(
+        f"email-personalisation-{saved_notification.id}",
+        json.dumps(personalisation),
+        ex=60 * 60,
+    )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
 
@@ -394,6 +405,11 @@ def send_user_confirm_new_email(user_id):
     )
     saved_notification.personalisation = personalisation
 
+    redis_store.set(
+        f"email-personalisation-{saved_notification.id}",
+        json.dumps(personalisation),
+        ex=60 * 60,
+    )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
     return jsonify({}), 204
 
@@ -486,6 +502,12 @@ def send_already_registered_email(user_id):
     saved_notification.personalisation = personalisation
 
     current_app.logger.info("Sending notification to queue")
+
+    redis_store.set(
+        f"email-personalisation-{saved_notification.id}",
+        json.dumps(personalisation),
+        ex=60 * 60,
+    )
 
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
@@ -614,6 +636,11 @@ def send_user_reset_password():
     )
     saved_notification.personalisation = personalisation
 
+    redis_store.set(
+        f"email-personalisation-{saved_notification.id}",
+        json.dumps(personalisation),
+        ex=60 * 60,
+    )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
     return jsonify({}), 204


### PR DESCRIPTION
## Description

When we removed personalisation from the database, it worked fine for text messages, because all text messages were converted into jobs with one code flow and we could therefore always retrieve the personalisation from the CSV files.

However, there are a number of email notifications that do various unusual tasks (reset password, 90 day verification, invites, etc.). These are not jobs and have no CSV file containing the personalisation.  So, we need to put the personalisation in redis so that it persists while the notification goes through the notification queue and awaits sending.

## Security Considerations

We want to make sure potential PII in the personalizations doesn't linger around in redis forever, so we should use the one hour timeout (ex=60*60) option to make sure redis deletes stuff when it doesn't need it any longer.