### PR TITLE
Add simulated sms numbers to allow list in trial mode.

### DIFF
--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -1,5 +1,6 @@
 import itertools
 
+from flask import current_app
 from notifications_utils.recipients import allowed_to_send_to
 
 from app.dao.services_dao import dao_fetch_service_by_id
@@ -45,6 +46,9 @@ def service_allowed_to_send_to(
         member.recipient for member in service.guest_list if allow_guest_list_recipients
     ]
 
+    # As per discussion we have decided to allow official simulated
+    # numbers to go out in trial mode for development purposes.
+    guest_list_members.extend(current_app.config["SIMULATED_SMS_NUMBERS"])
     if (key_type == KeyType.NORMAL and service.restricted) or (
         key_type == KeyType.TEAM
     ):

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -34,6 +34,7 @@ from app.serialised_models import (
     SerialisedService,
     SerialisedTemplate,
 )
+from app.service.utils import service_allowed_to_send_to
 from app.utils import get_template_instance
 from app.v2.errors import BadRequestError, RateLimitError, TotalRequestsError
 from tests.app.db import (
@@ -802,3 +803,21 @@ def test_check_service_over_total_message_limit(mocker, sample_service):
         sample_service,
     )
     assert service_stats == 0
+
+
+def test_service_allowed_to_send_to_simulated_numbers():
+    trial_mode_service = create_service(service_name="trial mode", restricted=True)
+    can_send = service_allowed_to_send_to(
+        "+14254147755",
+        trial_mode_service,
+        KeyType.NORMAL,
+        allow_guest_list_recipients=True,
+    )
+    can_not_send = service_allowed_to_send_to(
+        "+15555555555",
+        trial_mode_service,
+        KeyType.NORMAL,
+        allow_guest_list_recipients=True,
+    )
+    assert can_send is True
+    assert can_not_send is False


### PR DESCRIPTION
## Description

We recently had a discussion to allow devs to send to the simulated sms numbers while in trial mode. These changes are also further necessary for Cloudwatch alerts testing in staging. 

## TODO (optional)


- [ ] Check in paired PR in admin at the same time.


## Security Considerations

None. We are using simulated numbers through AWS.
