### PR TITLE
Adjust production worker memory to 1G

### DIFF
--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -2,7 +2,7 @@ env: production
 web_instances: 2
 web_memory: 1G
 worker_instances: 1
-worker_memory: 512M
+worker_memory: 1G
 scheduler_memory: 256M
 public_api_route: notify-api.app.cloud.gov
 admin_base_url: https://beta.notify.gov


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adjusts our worker process memory to 1G from 512MB in production. We recently saw memory-related crashes for the Celery worker processes, meaning they did not have enough available to them.  This was compounded by an [ongoing platform issue with cloud.gov](https://cloudgov.statuspage.io/incidents/78t5kvrx342z) due to Cloud Foundry VMs operating with a Linux kernel that has a memory allocation issue.

Fixes for the Linux kernel and Cloud Foundry VMs are in flight and cloud.gov is tracking this closely, but we can help ourselves in the mean time and given the increased usage with pilot partners, it makes sense to adjust this anyway.

## Security Considerations

- This change will help stabilize the application now and in the future.  We've already applied the change in production as a stop-gap measure, and this makes it a permanent change with future deployments.