### PR TITLE
1270 update email content

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -23,6 +23,7 @@
       "Click this link to create an account on Notify.gov:",
       "",
       "[Join Service](((url)))",
+      "If you’re new to Notify.gov you will first be directed to Login.gov create an account with us.",
       "",
       "",
       "This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure."


### PR DESCRIPTION
## Description

Small content update to the email a user gets when signing up for the Notify service to let them know they'll have to use Login.gov to sign in