### PR TITLE
Add cf org and space to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ in the command line by using this command:
 ```sh
 cf login -a api.fr.cloud.gov --sso
 ```
+If you are offered a choice of orgs, select `gsa-tts-benefits-studio`. For the space, choose `notify-local-dev` to start with.
 
 _REMINDER: Ensure you have access to the `notify-local-dev` and `notify-staging` spaces in cloud.gov_
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ in the command line by using this command:
 ```sh
 cf login -a api.fr.cloud.gov --sso
 ```
-If you are offered a choice of orgs, select `gsa-tts-benefits-studio`. For the space, choose `notify-local-dev` to start with.
+If you are offered a choice of orgs, select `gsa-tts-benefits-studio`.
+For the space, choose `notify-local-dev` to start with (assuming you are
+setting up local development).
 
 _REMINDER: Ensure you have access to the `notify-local-dev` and `notify-staging` spaces in cloud.gov_
 


### PR DESCRIPTION
Update the README to specify the org `gsa-tts-benefits-studio` and space `notify-local-dev` in the instructions for the `cf login` command