### PR TITLE
return None to handle new user

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -36,7 +36,6 @@ def get_login_gov_user(login_uuid, email_address):
     should be removed.
     """
 
-    print(User.query.filter_by(login_uuid=login_uuid).first())
     user = User.query.filter_by(login_uuid=login_uuid).first()
     if user:
         if user.email_address != email_address:

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -566,6 +566,9 @@ def get_user_login_gov_user():
     login_uuid = request_args["login_uuid"]
     email = request_args["email"]
     user = get_login_gov_user(login_uuid, email)
+
+    if user is None:
+        return jsonify({})
     result = user.serialize()
     return jsonify(data=result)
 
@@ -715,9 +718,9 @@ def get_orgs_and_services(user):
                 "id": service.id,
                 "name": service.name,
                 "restricted": service.restricted,
-                "organization": service.organization.id
-                if service.organization
-                else None,
+                "organization": (
+                    service.organization.id if service.organization else None
+                ),
             }
             for service in user.services
             if service.active


### PR DESCRIPTION
## Description

Originally login_dot_gov was handling sign in where we expected existing users to be in our database, and login_dot_gov was just providing the authentication.  With the new registration workflow, users may not actually exist in our database when they are invited.  So if we cannot find a user in our database, we have to return empty json and allow the Admin app to figure out what it's trying to do, instead of just blowing up because we cannot serialize a None object.

## Security Considerations

N/A