### PR TITLE
Fix organization invite template

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -161,7 +161,7 @@
       "",
       "Open this link to create an account on Notify.gov:",
       "",
-      "((url))",
+      "[Join Organization](((url)))",
       "",
       "",
       "This invitation will stop working at midnight tomorrow. This is to keep ((organization_name)) secure."


### PR DESCRIPTION
## Description

1. Change the link to [Join Organization](((url)))
2. Run `poetry run flask command update-templates`
3. Look in database and see that the organization invite has actually changed to what we want
4. Login in to app and issue an organization invite --- No Change!

I looked at send_to_providers.py and there's all this caching and template manipulation going on in notification_utils, sigh.  How do we clear this cache?

## Security Considerations

N/A