### PR TITLE
remove debug

### DIFF
--- a/app/organization/invite_rest.py
+++ b/app/organization/invite_rest.py
@@ -28,7 +28,6 @@ from app.organization.organization_schema import (
     post_update_invited_org_user_status_schema,
 )
 from app.schema_validation import validate
-from app.utils import hilite
 
 organization_invite_blueprint = Blueprint("organization_invite", __name__)
 
@@ -88,12 +87,6 @@ def invite_user_to_org(organization_id):
         redis_key,
         organization_id,
         ex=3600 * 24,
-    )
-    current_app.logger.info(
-        hilite(f"STORING THIS ORGANIZATION ID IN REDIS {redis_store.get(redis_key)}")
-    )
-    current_app.logger.info(
-        hilite(f"URL: {os.environ['LOGIN_DOT_GOV_REGISTRATION_URL']}")
     )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -25,7 +25,6 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.schemas import invited_user_schema
-from app.utils import hilite
 
 service_invite = Blueprint("service_invite", __name__)
 
@@ -80,9 +79,6 @@ def _create_service_invite(invited_user, invite_link_host):
         f"service-invite-{invited_user.email_address}",
         json.dumps(data),
         ex=3600 * 24,
-    )
-    current_app.logger.info(
-        hilite(f"STORING ALL THIS IN REDIS FOR SERVICE INVITE {json.dumps(data)}")
     )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 


### PR DESCRIPTION
## Description

Remove debug statements

## Security Considerations

Remove debug statements.  I'm trying to use the 'hilite' function copied from admin project to make it easier to find debug that is meant to be temporary.  Searching on 'print(' brings up all the Blueprint hits.