### PR TITLE
Add a note about how to resolve db error

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -262,6 +262,8 @@ This will run:
 - isort for import styling
 - pytest for the test suite
 
+If you see an error about a missing test database, run `createdb test_notification_api`.
+
 On GitHub, in addition to these tests, we run:
 - bandit for code security
 - pip-audit for dependency vulnerabilities


### PR DESCRIPTION
Apparently this error is common:
```
FATAL:  database "test_notification_api" does not exist
```

In lieu of getting to the bottom of it, add a note about how to fix it
