### PR TITLE
Revert recent Terraform changes to prod and demo

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -1,45 +1,38 @@
 locals {
-  cf_org_name              = "gsa-tts-benefits-studio"
-  cf_space_name            = "notify-demo"
-  env                      = "demo"
-  app_name                 = "notify-api"
-  delete_recursive_allowed = false
-}
-
-data "cloudfoundry_org" "org" {
-  name = local.cf_org_name
-}
-
-resource "cloudfoundry_space" "notify-demo" {
-  delete_recursive_allowed = local.delete_recursive_allowed
-  name                     = local.cf_space_name
-  org                      = data.cloudfoundry_org.org.id
+  cf_org_name      = "gsa-tts-benefits-studio"
+  cf_space_name    = "notify-demo"
+  env              = "demo"
+  app_name         = "notify-api"
+  recursive_delete = false
 }
 
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database?ref=v0.7.1"
 
-  cf_org_name   = local.cf_org_name
-  cf_space_name = local.cf_space_name
-  name          = "${local.app_name}-rds-${local.env}"
-  rds_plan_name = "micro-psql"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  name             = "${local.app_name}-rds-${local.env}"
+  recursive_delete = local.recursive_delete
+  rds_plan_name    = "micro-psql"
 }
 
 module "redis" {
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-dev"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  name             = "${local.app_name}-redis-${local.env}"
+  recursive_delete = local.recursive_delete
+  redis_plan_name  = "redis-dev"
 }
 
 module "csv_upload_bucket" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
-  cf_org_name   = local.cf_org_name
-  cf_space_name = local.cf_space_name
-  name          = "${local.app_name}-csv-upload-bucket-${local.env}"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  recursive_delete = local.recursive_delete
+  name             = "${local.app_name}-csv-upload-bucket-${local.env}"
 }
 
 module "egress-space" {
@@ -47,7 +40,6 @@ module "egress-space" {
 
   cf_org_name              = local.cf_org_name
   cf_restricted_space_name = local.cf_space_name
-  delete_recursive_allowed = local.delete_recursive_allowed
   deployers = [
     var.cf_user,
     "steven.reilly@gsa.gov"
@@ -60,6 +52,7 @@ module "ses_email" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
+  recursive_delete    = local.recursive_delete
   aws_region          = "us-west-2"
   email_domain        = "notify.sandbox.10x.gsa.gov"
   email_receipt_error = "notify-support@gsa.gov"
@@ -71,6 +64,7 @@ module "sns_sms" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-sns-${local.env}"
+  recursive_delete    = local.recursive_delete
   aws_region          = "us-east-1"
   monthly_spend_limit = 25
 }

--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.53.1"
+      version = "0.53.0"
     }
   }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -1,56 +1,45 @@
 locals {
-  cf_org_name              = "gsa-tts-benefits-studio"
-  cf_space_name            = "notify-production"
-  env                      = "production"
-  app_name                 = "notify-api"
-  delete_recursive_allowed = false
-  allow_ssh                = false
-}
-
-data "cloudfoundry_org" "org" {
-  name = local.cf_org_name
-}
-
-resource "cloudfoundry_space" "notify-production" {
-  allow_ssh                = local.allow_ssh
-  delete_recursive_allowed = local.delete_recursive_allowed
-  name                     = local.cf_space_name
-  org                      = data.cloudfoundry_org.org.id
+  cf_org_name      = "gsa-tts-benefits-studio"
+  cf_space_name    = "notify-production"
+  env              = "production"
+  app_name         = "notify-api"
+  recursive_delete = false
 }
 
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database?ref=v0.7.1"
 
-  cf_org_name   = local.cf_org_name
-  cf_space_name = local.cf_space_name
-  name          = "${local.app_name}-rds-${local.env}"
-  rds_plan_name = "small-psql-redundant"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  name             = "${local.app_name}-rds-${local.env}"
+  recursive_delete = local.recursive_delete
+  rds_plan_name    = "small-psql-redundant"
 }
 
 module "redis" {
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-3node-large"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  name             = "${local.app_name}-redis-${local.env}"
+  recursive_delete = local.recursive_delete
+  redis_plan_name  = "redis-3node-large"
 }
 
 module "csv_upload_bucket" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
-  cf_org_name   = local.cf_org_name
-  cf_space_name = local.cf_space_name
-  name          = "${local.app_name}-csv-upload-bucket-${local.env}"
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  recursive_delete = local.recursive_delete
+  name             = "${local.app_name}-csv-upload-bucket-${local.env}"
 }
 
 module "egress-space" {
   source = "../shared/egress_space"
 
-  allow_ssh                = local.allow_ssh
   cf_org_name              = local.cf_org_name
   cf_restricted_space_name = local.cf_space_name
-  delete_recursive_allowed = local.delete_recursive_allowed
   deployers = [
     var.cf_user
   ]
@@ -62,6 +51,7 @@ module "ses_email" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
+  recursive_delete    = local.recursive_delete
   aws_region          = "us-gov-west-1"
   email_domain        = "notify.gov"
   mail_from_subdomain = "mail"
@@ -74,6 +64,7 @@ module "sns_sms" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-sns-${local.env}"
+  recursive_delete    = local.recursive_delete
   aws_region          = "us-gov-west-1"
   monthly_spend_limit = 1000
 }

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.53.1"
+      version = "0.53.0"
     }
   }
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset reverts a few of our recent changes to the production and demo Terraform files to re-enable deployments.

We are working through fixing this and will re-introduce these changes once we figure out how to get the changes to properly work (which are tied to the infrastructure checks as well).

## Security Considerations

- This will re-introduce several deprecation warnings in the infrastructure verification checks, but they will be non-blocking.