### PR TITLE
add login.gov env vars to sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -50,3 +50,6 @@ NOTIFY_E2E_TEST_PASSWORD="don't write secrets to the sample file"
 FLASK_APP=application.py
 FLASK_DEBUG=true
 WERKZEUG_DEBUG_PIN=off
+
+
+LOGIN_DOT_GOV_REGISTRATION_URL="https://idp.int.identitysandbox.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:test_notify_gov&nonce=NONCE&prompt=select_account&redirect_uri=http://localhost:6012/set-up-your-profile&response_type=code&scope=openid+email&state=STATE"


### PR DESCRIPTION
## Description

Add/fix necessary environment variables to run login.gov in local dev environment.


## Security Considerations

N/A