### PR TITLE
Terraform doc update

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,13 +6,15 @@ Prerequisite: install the `jq` JSON processor: `brew install jq`
 
 ## Initial setup
 
+These instructions were used for deploying the project for the first time, years ago. We should not have to perfrom these steps again. They are provided here for reference.
+
 1. Manually run the bootstrap module following instructions under `Terraform State Credentials`
 1. Setup CI/CD Pipeline to run Terraform
-  1. Copy bootstrap credentials to your CI/CD secrets using the instructions in the base README
-  1. Create a cloud.gov SpaceDeployer by following the instructions under `SpaceDeployers`
-  1. Copy SpaceDeployer credentials to your CI/CD secrets using the instructions in the base README
+    1. Copy bootstrap credentials to your CI/CD secrets using the instructions in the base README
+    1. Create a cloud.gov SpaceDeployer by following the instructions under `SpaceDeployers`
+    1. Copy SpaceDeployer credentials to your CI/CD secrets using the instructions in the base README
 1. Manually Running Terraform
-  1. Follow instructions under `Set up a new environment` to create your infrastructure
+    1. Follow instructions under `Set up a new environment` to create your infrastructure
 
 ## Terraform State Credentials
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,17 +6,17 @@ Prerequisite: install the `jq` JSON processor: `brew install jq`
 
 ## Initial setup
 
-These instructions were used for deploying the project for the first time, years ago. We should not have to perfrom these steps again. They are provided here for reference.
+These instructions were used for deploying the project for the first time, years ago. We should not have to perform these steps again. They are provided here for reference.
 
-1. Manually run the bootstrap module following instructions under `Terraform State Credentials`
+1. Manually run the bootstrap module following instructions under [Terraform State Credentials](#terraform-state-credentials)
 1. Setup CI/CD Pipeline to run Terraform
     1. Copy bootstrap credentials to your CI/CD secrets using the instructions in the base README
-    1. Create a cloud.gov SpaceDeployer by following the instructions under `SpaceDeployers`
+    1. Create a cloud.gov SpaceDeployer by following the instructions under [SpaceDeployers](#spacedeployers)
     1. Copy SpaceDeployer credentials to your CI/CD secrets using the instructions in the base README
 1. Manually Running Terraform
-    1. Follow instructions under `Set up a new environment` to create your infrastructure
+    1. Follow instructions under [Set up a new environment manually](#set-up-a-new-environment-manually) to create your infrastructure
 
-## Terraform State Credentials
+## Terraform state credentials
 
 The bootstrap module is used to create an s3 bucket for later terraform runs to store their state in.
 
@@ -25,7 +25,7 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
 1. Run `terraform init`
 1. Run `./run.sh plan` to verify that the changes are what you expect
 1. Run `./run.sh apply` to set up the bucket and retrieve credentials
-1. Follow instructions under `Use bootstrap credentials`
+1. Follow instructions under [Use bootstrap credentials](#use-bootstrap-credentials)
 1. Ensure that `import.sh` includes a line and correct IDs for any resources created
 1. Run `./teardown_creds.sh` to remove the space deployer account used to create the s3 bucket
 1. Copy `bucket` from `bucket_credentials` output to the backend block of `staging/providers.tf` and `production/providers.tf`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,12 +1,10 @@
 # Terraform
 
-This directory holds the terraform modules for maintaining your complete persistent infrastructure.
-
-Prerequisite: install the `jq` JSON processor: `brew install jq`
+This directory holds the Terraform modules for maintaining Notify.gov's infrastructure. You can [read about the structure](#structure) or [get set up to develop](#retrieving-existing-bucket-credentials).
 
 ## Retrieving existing bucket credentials
 
-Assuming [initial setup](#initial-setup) is complete, new developers start here!
+:green_book: Assuming [initial setup](#initial-setup) is complete, new developers start here!
 
 1. Enter the bootstrap module with `cd bootstrap`
 1. Run `./import.sh` to pull existing terraform state into the local state
@@ -35,11 +33,11 @@ These instructions were used for deploying the project for the first time, years
 1. Manually Running Terraform
     1. Follow instructions under [Set up a new environment manually](#set-up-a-new-environment-manually) to create your infrastructure
 
-## Terraform state credentials
+### Terraform state credentials
 
 The bootstrap module is used to create an s3 bucket for later terraform runs to store their state in.
 
-### Bootstrapping the state storage s3 buckets for the first time
+#### Bootstrapping the state storage s3 buckets for the first time
 
 1. Within the `bootstrap` directory, run `terraform init`
 1. Run `./run.sh plan` to verify that the changes are what you expect
@@ -49,7 +47,7 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
 1. Run `./teardown_creds.sh` to remove the space deployer account used to create the s3 bucket
 1. Copy `bucket` from `bucket_credentials` output to the backend block of `staging/providers.tf` and `production/providers.tf`
 
-### To make changes to the bootstrap module
+#### To make changes to the bootstrap module
 
 *This should not be necessary in most cases*
 
@@ -106,7 +104,13 @@ The below steps rely on you first configuring access to the Terraform state in s
 
 ## Structure
 
-Each environment has its own module, which relies on a shared module for everything except the providers code and environment specific variables and settings.
+The `terraform` directory contains sub-directories (`staging`, `production`, etc.) named for deployment environments. Each of these is a *module*, which is just Terraform's word for a directory with some .tf files in it. Each module governs the infrastructure of the environment for which it is named. This directory structure forms "[bulkheads](https://blog.gruntwork.io/how-to-manage-terraform-state-28f5697e68fa)" which isolate Terraform commands to a single environment, limiting accidental damage.
+
+The `development` module is rather different from the other environment modules. While the other environments can be used to create (or destroy) cloud resources, the development module mostly just sets up access to pre-existing resources needed for local software development.
+
+The `bootstrap` directory is not an environment module. Instead, it sets up infrastructure needed to deploy Terraform in any of the environments. If you are new to the project, [this is where you should start](#retrieving-existing-bucket-credentials). Similarly, `shared` is not an environment; this module lends code to all the environments.
+
+Files within these directories look like this:
 
 ```
 - bootstrap/

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
 1. Follow instructions under `Use bootstrap credentials`
 1. Ensure that `import.sh` includes a line and correct IDs for any resources created
 1. Run `./teardown_creds.sh` to remove the space deployer account used to create the s3 bucket
+1. Copy `bucket` from `bucket_credentials` output to the backend block of `staging/providers.tf` and `production/providers.tf`
 
 ### To make changes to the bootstrap module
 
@@ -40,6 +41,7 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
 
 ### Retrieving existing bucket credentials
 
+1. Run `./import.sh` to pull existing terraform state into the local state
 1. Run `./run.sh show`
 1. Follow instructions under `Use bootstrap credentials`
 
@@ -51,8 +53,6 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
     aws_access_key_id = <access_key_id from bucket_credentials>
     aws_secret_access_key = <secret_access_key from bucket_credentials>
     ```
-
-1. Copy `bucket` from `bucket_credentials` output to the backend block of `staging/providers.tf` and `production/providers.tf`
 
 ## SpaceDeployers
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,6 +4,25 @@ This directory holds the terraform modules for maintaining your complete persist
 
 Prerequisite: install the `jq` JSON processor: `brew install jq`
 
+## Retrieving existing bucket credentials
+
+Assuming [initial setup](#initial-setup) is complete, new developers start here!
+
+1. Enter the bootstrap module with `cd bootstrap`
+1. Run `./import.sh` to pull existing terraform state into the local state
+1. Follow instructions under [Use bootstrap credentials](#use-bootstrap-credentials)
+
+### Use bootstrap credentials
+
+1. Run `./run.sh show -json`.
+1. In the output, locate `access_key_id` and `secret_access_key` within `bucket_credentials`. These values are secret, so, don't share them with anyone or copy them to anywhere online.
+1. Add the following to `~/.aws/credentials`:
+    ```
+    [notify-terraform-backend]
+    aws_access_key_id = <access_key_id from bucket_credentials>
+    aws_secret_access_key = <secret_access_key from bucket_credentials>
+    ```
+
 ## Initial setup
 
 These instructions were used for deploying the project for the first time, years ago. We should not have to perform these steps again. They are provided here for reference.
@@ -22,9 +41,9 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
 
 ### Bootstrapping the state storage s3 buckets for the first time
 
-1. Run `terraform init`
+1. Within the `bootstrap` directory, run `terraform init`
 1. Run `./run.sh plan` to verify that the changes are what you expect
-1. Run `./run.sh apply` to set up the bucket and retrieve credentials
+1. Run `./run.sh apply` to set up the bucket
 1. Follow instructions under [Use bootstrap credentials](#use-bootstrap-credentials)
 1. Ensure that `import.sh` includes a line and correct IDs for any resources created
 1. Run `./teardown_creds.sh` to remove the space deployer account used to create the s3 bucket
@@ -40,21 +59,6 @@ The bootstrap module is used to create an s3 bucket for later terraform runs to 
     1. optionally run `./run.sh apply` to include the existing outputs in the state file
 1. Make your changes
 1. Continue from step 2 of the boostrapping instructions
-
-### Retrieving existing bucket credentials
-
-1. Run `./import.sh` to pull existing terraform state into the local state
-1. Run `./run.sh show`
-1. Follow instructions under `Use bootstrap credentials`
-
-#### Use bootstrap credentials
-
-1. Add the following to `~/.aws/credentials`
-    ```
-    [notify-terraform-backend]
-    aws_access_key_id = <access_key_id from bucket_credentials>
-    aws_secret_access_key = <secret_access_key from bucket_credentials>
-    ```
 
 ## SpaceDeployers
 

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -14,7 +14,3 @@ resource "cloudfoundry_service_key" "bucket_creds" {
   name             = "${local.s3_service_name}-access"
   service_instance = module.s3.bucket_id
 }
-
-output "bucket_credentials" {
-  value = cloudfoundry_service_key.bucket_creds.credentials
-}


### PR DESCRIPTION
## Changes

There are 3 major themes to the changes here:
1. Remove credentials output
2. Adjust README to get credentials another way
3. Re-order and add to README for new developers as the intended audience

## Reasons

Why remove the `output` block from the bootstrap Terraform?
* Attempts to output sensitive values, like credentials, halt execution in newer versions of Terraform
* The output was only used in Initial Setup instructions, which are now complete
* Don't want to risk credential output to log files
* [The same purpose can be accomplished](https://discuss.hashicorp.com/t/how-to-show-sensitive-values/24076) with the `show -json` command

Why so many edits to the README?
* The original README is largely boilerplate intended to guide the creator of a new project
* We are long past the initial setup, so those instructions can be deprioritized

## TODO

- [ ] Importing the state bucket in `./import.sh` seems unnecessary because the bucket is already managed by Terraform
- [ ] Briefly, explain the purpose of adding creds to `~/.aws/credentials`
- [ ] Should the sections *SpaceDeployers* and *Set up a new environment manually* be nested under the *Initial setup* heading, and thus deprioritized?

