### PR TITLE
Added ability for poetry to add and delete the test_notifications_api db during tests for #598

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4800,4 +4800,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12.2"
-content-hash = "4c2122299adba83cf4d541bdc16a6b5d3a5350cb96158d2a6a4a033f78ee612b"
+content-hash = "fa95df65f7a51c8bc919a756d57b7f1fa36ad7ffbf5725be1f929bea21be6c20"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2488,7 +2488,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
-    {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
 ]
 
 [[package]]
@@ -3529,7 +3529,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4283,6 +4282,34 @@ pymysql = ["pymysql", "pymysql (<1)"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
+name = "sqlalchemy-utils"
+version = "0.41.2"
+description = "Various utility functions for SQLAlchemy."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "SQLAlchemy-Utils-0.41.2.tar.gz", hash = "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"},
+    {file = "SQLAlchemy_Utils-0.41.2-py3-none-any.whl", hash = "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e"},
+]
+
+[package.dependencies]
+SQLAlchemy = ">=1.3"
+
+[package.extras]
+arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
+encrypted = ["cryptography (>=0.6)"]
+intervals = ["intervals (>=0.7.1)"]
+password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["Jinja2 (>=2.3)", "Pygments (>=1.2)", "backports.zoneinfo", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "isort (>=4.2.2)", "pg8000 (>=1.12.4)", "psycopg (>=3.1.8)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (==7.4.4)", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+test-all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "backports.zoneinfo", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg (>=3.1.8)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (==7.4.4)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
+
+[[package]]
 name = "stevedore"
 version = "5.2.0"
 description = "Manage dynamic plugins for Python applications"
@@ -4773,4 +4800,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12.2"
-content-hash = "3dcc493bc45068a1875df77b6488c9311e91f9a192fad1df14aa62b0a40879c4"
+content-hash = "4c2122299adba83cf4d541bdc16a6b5d3a5350cb96158d2a6a4a033f78ee612b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ sqlalchemy = "==1.4.40"
 werkzeug = "^3.0.2"
 faker = "^24.4.0"
 setuptools = "^69.2.0"
+sqlalchemy-utils = "^0.41.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ sqlalchemy = "==1.4.40"
 werkzeug = "^3.0.2"
 faker = "^24.4.0"
 setuptools = "^69.2.0"
-sqlalchemy-utils = "^0.41.2"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -78,6 +77,7 @@ pytest-xdist = "^3.5.0"
 radon = "^6.0.1"
 requests-mock = "^1.11.0"
 setuptools = "^69.0.3"
+sqlalchemy-utils = "^0.41.2"
 vulture = "^2.10"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from alembic.command import upgrade
 from alembic.config import Config
 from flask import Flask
-from sqlalchemy_utils import database_exists, create_database, drop_database
+from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from app import create_app
 from app.dao.provider_details_dao import get_provider_details_by_identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from alembic.command import upgrade
 from alembic.config import Config
 from flask import Flask
+from sqlalchemy_utils import database_exists, create_database, drop_database
 
 from app import create_app
 from app.dao.provider_details_dao import get_provider_details_by_identifier
@@ -52,9 +53,10 @@ def _notify_db(notify_api):
     """
     with notify_api.app_context() as app_context:
         db = app_context.app.extensions["sqlalchemy"]
-        assert (
-            "test_notification_api" in db.engine.url.database
-        ), "dont run tests against main db"
+
+        # Check if test_notification_api exists, if not, create
+        if not database_exists(db.engine.url):
+            create_database(db.engine.url)
 
         BASE_DIR = os.path.dirname(os.path.dirname(__file__))
         ALEMBIC_CONFIG = os.path.join(BASE_DIR, "migrations")
@@ -70,6 +72,9 @@ def _notify_db(notify_api):
         yield db
 
         db.session.remove()
+        # Check if test_notification_api exists, if so, drop
+        if database_exists(db.engine.url):
+            drop_database(db.engine.url)
         db.engine.dispose()
 
 


### PR DESCRIPTION


## Description

Installed the python library sqlalchemy-utils which contains the methods database_exists, create_database, drop_database. I modified the _notify_db method in conftest.py to allow for the method to check if the test_notifications_api db exists, if it does it will create it. After all tests run and during deconstruction, the _notify_db method will then remove the test_notifications_api database as part of it's cleanup. 

This should include:

- Links to issues that this PR addresses
https://github.com/GSA/notifications-api/issues/598
- Screenshots or screen captures of any visible changes, especially for UI work
NA
- Dependency changes
Added sqlalchemy-utils to poetry lock

## Security Considerations

NA
