### PR TITLE
Upgrade terraform version to match CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Terraform installations. This is great, but you still need to install Terraform
 itself, which can be done with this command:
 
 ```sh
-tfenv install latest:^1.4.0
+tfenv install "latest:^1.8.0"
 ```
 
-_NOTE: This project currently uses the latest `1.4.x release of Terraform._
+_NOTE: This project currently uses the latest `1.8.x release of Terraform._
 
 #### Python Installation
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,9 @@ Terraform installations. This is great, but you still need to install Terraform
 itself, which can be done with this command:
 
 ```sh
-tfenv install "latest:^1.8.0"
+tfenv install "latest:^1.7"
+tfenv use 1.7.x # x = the patch version installed
 ```
-
-_NOTE: This project currently uses the latest `1.8.x release of Terraform._
 
 #### Python Installation
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -208,3 +208,9 @@ Error: You are not authorized to perform the requested action
 This error indicates that the Cloud Foundry user account (or service account) needs OrgManager permissions to take the action.
 * When you create a SpaceDeployer service account, use the `-m` flag when running the `./create_service_account.sh` script
 * Your own CF user may may also require OrgManager permissions to run the script
+
+### Services limit
+```
+You have exceeded your organization's services limit.
+```
+Too many Cloud Foundry services have been created without being destroyed. Perhaps Terraform developers have forgotten to delete their SpaceDeployers after they finish with them. List `cf services` to see.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -89,16 +89,18 @@ These steps assume shared [Terraform state credentials](#terraform-state-credent
 
 1. Run `cf spaces` and, from the output, copy the space name for the environment you are working in, such as `notify-sandbox`.
 
-1. Next you will set up a SpaceDeployer. Prepare to fill in these values:
-   * `<SPACE_NAME>` will be the string you copied from the prior step
-   * `<ACCOUNT_NAME>` can be anything, although we recommend something that communicates the purpose of the deployer. For example: "circleci-deployer" for the credentials CircleCI uses to deploy the application, or "sandbox-<your_name>" for credentials to run terraform manually.
+1. Next you will set up a SpaceDeployer service account instance. This is something like a stub user account, just for deployment. Note these two values which you will use both to create and destroy the account:
+    1. `<SPACE_NAME>` will be the string you copied from the prior step
+    1. `<ACCOUNT_NAME>` can be anything, although we recommend something that communicates the purpose of the deployer. For example: "circleci-deployer" for the credentials CircleCI uses to deploy the application, or "sandbox-<your_name>" for credentials to run terraform manually.
 
-   Put those two values into this command:
+    Put those two values into this command:
     ```bash
-    ./create_service_account.sh -s <SPACE_NAME> -u <ACCOUNT_NAME> > secrets.auto.tfvars
+    ../create_service_account.sh -s <SPACE_NAME> -u <ACCOUNT_NAME> > secrets.auto.tfvars
     ```
 
     The script will output the `username` (as `cf_user`) and `password` (as `cf_password`) for your `<ACCOUNT_NAME>`. The [cloud.gov service account documentation](https://cloud.gov/docs/services/cloud-gov-service-account/) has more information.
+
+    Some resources you might work on require a SpaceDeployer account with higher permissions. Add the `-m` flag to the command to get this.
 
     The command uses the redirection operator (`>`) to write that output to the `secrets.auto.tfvars` file. Terraform will find the username and password there, and use them as input variables.
 
@@ -136,6 +138,8 @@ These steps assume shared [Terraform state credentials](#terraform-state-credent
     # <SPACE_NAME> and <ACCOUNT_NAME> have the same values as used above.
     ./destroy_service_account.sh -s <SPACE_NAME> -u <ACCOUNT_NAME>
     ```
+
+    List `cf services` if you are unsure which space deployer service instances still exist
 
     Optionally, you can also `rm secrets.auto.tfvars`
 
@@ -195,3 +199,12 @@ You need to re-authenticate with the Cloud Foundry CLI
 cf login -a api.fr.cloud.gov --sso
 ```
 You may also need to log in again to the Cloud.gov website.
+
+### CF account not authorized
+
+```
+Error: You are not authorized to perform the requested action
+```
+This error indicates that the Cloud Foundry user account (or service account) needs OrgManager permissions to take the action.
+* When you create a SpaceDeployer service account, use the `-m` flag when running the `./create_service_account.sh` script
+* Your own CF user may may also require OrgManager permissions to run the script

--- a/terraform/bootstrap/providers.tf
+++ b/terraform/bootstrap/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/bootstrap/providers.tf
+++ b/terraform/bootstrap/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/demo/providers.tf
+++ b/terraform/demo/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/development/providers.tf
+++ b/terraform/development/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/production/providers.tf
+++ b/terraform/production/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/sandbox/providers.tf
+++ b/terraform/sandbox/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/sandbox/providers.tf
+++ b/terraform/sandbox/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/egress_space/providers.tf
+++ b/terraform/shared/egress_space/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/egress_space/providers.tf
+++ b/terraform/shared/egress_space/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/ses/providers.tf
+++ b/terraform/shared/ses/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/ses/providers.tf
+++ b/terraform/shared/ses/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/sns/providers.tf
+++ b/terraform/shared/sns/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/shared/sns/providers.tf
+++ b/terraform/shared/sns/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/staging/providers.tf
+++ b/terraform/staging/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.8"
+  required_version = "~> 1.7"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"

--- a/terraform/staging/providers.tf
+++ b/terraform/staging/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.8"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"


### PR DESCRIPTION
## Description

Update our Terraform version requirement to what our CI/CD is using. This precaution ensures no one develops against an old version with breaking changes.

* Upgrade the minimum Terraform version across the codebase to v1.7.x
* Update the main README to reflect this Terraform version
* 🏆 *Bonus!* Update the terraform dir README with Troubleshooting info on service account permissions

## Deployment

⚠️ This changes the Terraform configuration of *all* our environments. Only deploy to higher environments after the change has been deployed and validated in lower ones.
