### PR TITLE
Import notify-sandbox space

### DIFF
--- a/terraform/sandbox/imports.tf
+++ b/terraform/sandbox/imports.tf
@@ -1,0 +1,8 @@
+# Brings resources created outside of Terraform (e.g. created via "ClickOps")
+# under Terraform managmenet. The id required by the import block comes from:
+# `cf space notify-sandbox --guid`
+
+import {
+  to = cloudfoundry_space.notify-sandbox
+  id = "420bb231-f99f-4dea-8cda-d342981d2718"
+}

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -6,6 +6,17 @@ locals {
   recursive_delete = true
 }
 
+data "cloudfoundry_org" "org" {
+  name = local.cf_org_name
+}
+
+# This resource imported in imports.tf
+resource "cloudfoundry_space" "notify-sandbox" {
+  delete_recursive_allowed = true
+  name                     = local.cf_space_name
+  org                      = data.cloudfoundry_org.org.id
+}
+
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database?ref=v0.7.1"
 


### PR DESCRIPTION
## Description

Brings a "space," a thing which exists out on Cloud.gov, under Terraform management 

* Restore the `notify-sandbox` Cloud Foundry space resource that was removed in #891 
* Add `import` block that hooks up to the existing space

This is a preliminary, experimental restoration of a bunch of Terraform configuration changes. More PRs to come if this works out.

## To do

Because I wanted to create the smallest possible delta that would prove the concept of importing a space, there are things this PR *dosen't* do, but a later one will:
* remove the deprecated `recursive_delete` argument 
* use the `prevent_destroy` argument
* use local variables at all

## Deployment

The `import` bock used in this PR is supported only by Terraform v1.5 and above. It relies on PR #923 which ensures the Terraform version number is at least this high.

🛠️  Only deploy this PR *after* number 923 has been deployed and verified