### PR TITLE
Remove recursive_delete, add prevent_destroy

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -14,6 +14,9 @@ resource "cloudfoundry_space" "notify-sandbox" {
   delete_recursive_allowed = true
   name                     = local.cf_space_name
   org                      = data.cloudfoundry_org.org.id
+  asgs                     = [
+    "71d5aa70-fdce-46fa-8494-aabdb8cae381" # trusted_local_networks_egress
+  ]
   lifecycle {
     prevent_destroy = false # sandbox is ephemeral; delete and destroy OK
   }

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -1,9 +1,8 @@
 locals {
-  cf_org_name      = "gsa-tts-benefits-studio"
-  cf_space_name    = "notify-sandbox"
-  env              = "sandbox"
-  app_name         = "notify-api"
-  recursive_delete = true
+  cf_org_name   = "gsa-tts-benefits-studio"
+  cf_space_name = "notify-sandbox"
+  env           = "sandbox"
+  app_name      = "notify-api"
 }
 
 data "cloudfoundry_org" "org" {
@@ -15,35 +14,35 @@ resource "cloudfoundry_space" "notify-sandbox" {
   delete_recursive_allowed = true
   name                     = local.cf_space_name
   org                      = data.cloudfoundry_org.org.id
+  lifecycle {
+    prevent_destroy = false # sandbox is ephemeral; delete and destroy OK
+  }
 }
 
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database?ref=v0.7.1"
 
-  cf_org_name      = local.cf_org_name
-  cf_space_name    = local.cf_space_name
-  name             = "${local.app_name}-rds-${local.env}"
-  recursive_delete = local.recursive_delete
-  rds_plan_name    = "micro-psql"
+  cf_org_name   = local.cf_org_name
+  cf_space_name = local.cf_space_name
+  name          = "${local.app_name}-rds-${local.env}"
+  rds_plan_name = "micro-psql"
 }
 
 module "redis" {
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
-  cf_org_name      = local.cf_org_name
-  cf_space_name    = local.cf_space_name
-  name             = "${local.app_name}-redis-${local.env}"
-  recursive_delete = local.recursive_delete
-  redis_plan_name  = "redis-dev"
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-${local.env}"
+  redis_plan_name = "redis-dev"
 }
 
 module "csv_upload_bucket" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
-  cf_org_name      = local.cf_org_name
-  cf_space_name    = local.cf_space_name
-  recursive_delete = local.recursive_delete
-  name             = "${local.app_name}-csv-upload-bucket-${local.env}"
+  cf_org_name   = local.cf_org_name
+  cf_space_name = local.cf_space_name
+  name          = "${local.app_name}-csv-upload-bucket-${local.env}"
 }
 
 module "egress-space" {
@@ -64,7 +63,6 @@ module "ses_email" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
-  recursive_delete    = local.recursive_delete
   aws_region          = "us-west-2"
   email_receipt_error = "notify-support@gsa.gov"
 }
@@ -75,7 +73,6 @@ module "sns_sms" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-sns-${local.env}"
-  recursive_delete    = local.recursive_delete
   aws_region          = "us-east-2"
   monthly_spend_limit = 1
 }


### PR DESCRIPTION
## Description

Modernize the notation for allowing delete / destroy of sandbox resources. This will prove the method to *prevent* delete / destroy in higher deployed environments.

* remove deprecated `recursive_delete` argument
* substitute `prevent_destroy` argument

😕 *Oddity:* Because the `lifecycle` block [does not accept variables](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#literal-values-only) I eliminated the local variable that controlled deleting.

## Deployment

This branches off of #925 which in turn is dependent upon #923 

⚠️ Do not merge until 923 and 925 have both been merged, deployed, and validated