### PR TITLE
Import notify-management space

### DIFF
--- a/terraform/bootstrap/imports.tf
+++ b/terraform/bootstrap/imports.tf
@@ -1,0 +1,10 @@
+# The notify-management space contains resources that don't belong in our
+# deployed environment spaces (notify-sandbox, etc.) including:
+#   * the bucket that holds Terraform state
+#   * supplemental service brokers, letting cloud.gov provision AWS services
+#   * some service accounts used for deployment
+
+import {
+  to = cloudfoundry_space.notify-management
+  id = "a022fabe-056c-4329-9d4f-3f7a67442d36"
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -13,8 +13,9 @@ resource "cloudfoundry_space" "notify-management" {
   name                     = local.cf_space_name
   org                      = data.cloudfoundry_org.org.id
   asgs                     = [
-    "71d5aa70-fdce-46fa-8494-aabdb8cae381",
-    "c70d6061-4da3-4cbb-bd8e-c9982a5e8b22",
+    "71d5aa70-fdce-46fa-8494-aabdb8cae381", # trusted_local_networks_egress
+    "c70d6061-4da3-4cbb-bd8e-c9982a5e8b22", # public_networks_egress
+    # Public egress is needed for service brokers's Terraform to reach AWS APIs
   ]
   lifecycle {
     # Never delete the bucket that holds Terraform state nor the other

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,12 +1,33 @@
 locals {
+  cf_org_name     = "gsa-tts-benefits-studio"
+  cf_space_name   = "notify-management"
   s3_service_name = "notify-terraform-state"
+}
+
+data "cloudfoundry_org" "org" {
+  name = local.cf_org_name
+}
+
+resource "cloudfoundry_space" "notify-management" {
+  delete_recursive_allowed = false
+  name                     = local.cf_space_name
+  org                      = data.cloudfoundry_org.org.id
+  asgs                     = [
+    "71d5aa70-fdce-46fa-8494-aabdb8cae381",
+    "c70d6061-4da3-4cbb-bd8e-c9982a5e8b22",
+  ]
+  lifecycle {
+    # Never delete the bucket that holds Terraform state nor the other
+    # important contents of the notify-management space
+    prevent_destroy = true
+  }
 }
 
 module "s3" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 
   cf_org_name   = "gsa-tts-benefits-studio"
-  cf_space_name = "notify-management"
+  cf_space_name = local.cf_space_name
   name          = local.s3_service_name
 }
 


### PR DESCRIPTION
## Description

Importing the `notify-management` space under Terraform management, with a `prevent_destroy` on it

## Deployment

⚠️ Only deploy this after all other currently outstanding Terraform PRs have been deployed and verified, namely #922, #923, #925, #926, and #928


