### PR TITLE
make email_address check case insensitive

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -54,7 +54,8 @@ def get_login_gov_user(login_uuid, email_address):
 
         return user
     # Remove this 1 July 2025, all users should have login.gov uuids by now
-    user = User.query.filter_by(email_address=email_address).first()
+    user = User.query.filter(User.email_address.ilike(email_address)).first()
+    print(f"USER IS {user.email_address}")
     if user:
         save_user_attribute(user, {"login_uuid": login_uuid})
         return user


### PR DESCRIPTION
## Description

The db check between what we had stored in the users table and what was coming from login.gov was case sensitive, and people seem to write their emails differently for different apps.

## Security Considerations

N/A