### PR TITLE
use raw_get and raw_set for better debug of redis

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -91,13 +91,15 @@ def _create_service_invite(invited_user, invite_link_host):
     # This is for the login.gov service invite on the
     # "Set Up Your Profile" path.
     redis_key = f"service-invite-{invited_user.email_address}"
-    redis_store.set(
+    redis_store.raw_set(
         redis_key,
         json.dumps(data),
         ex=3600 * 24,
     )
     # TODO REMOVE DEBUG
     print(hilite(f"Save this data {data} with this redis_key {redis_key}"))
+    did_we_save_it = redis_store.raw_get(redis_key)
+    print(hilite(f"Did we save the data successfully? {did_we_save_it}"))
     # END DEBUG
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -31,6 +31,9 @@ def test_create_invited_user(
     extra_args,
     expected_start_of_invite_url,
 ):
+    mocker.patch("app.service_invite.rest.redis_store.raw_set")
+    mocker.patch("app.service_invite.rest.redis_store.raw_get")
+
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     email_address = "invited_user@service.gov.uk"
     invite_from = sample_service.users[0]
@@ -92,6 +95,9 @@ def test_create_invited_user(
 def test_create_invited_user_without_auth_type(
     admin_request, sample_service, mocker, invitation_email_template
 ):
+
+    mocker.patch("app.service_invite.rest.redis_store.raw_set")
+    mocker.patch("app.service_invite.rest.redis_store.raw_get")
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     email_address = "invited_user@service.gov.uk"
     invite_from = sample_service.users[0]
@@ -213,6 +219,9 @@ def test_resend_expired_invite(
     invitation_email_template,
     mocker,
 ):
+
+    mocker.patch("app.service_invite.rest.redis_store.raw_set")
+    mocker.patch("app.service_invite.rest.redis_store.raw_get")
     url = f"/service/{sample_expired_user.service_id}/invite/{sample_expired_user.id}/resend"
     mock_send = mocker.patch("app.service_invite.rest.send_notification_to_queue")
     mock_persist = mocker.patch("app.service_invite.rest.persist_notification")


### PR DESCRIPTION
## Description

We need more visibility into what is going wrong with redis.  Use raw_set and raw_get which are not wrapped and will raise Exceptions, etc.

## Security Considerations

N/A