### PR TITLE
api to return service invite info

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -223,3 +223,14 @@ def validate_service_invitation_token(token):
 
     invited_user = get_invited_user_by_id(invited_user_id)
     return jsonify(data=invited_user_schema.dump(invited_user)), 200
+
+
+@service_invite.route("/service/invite/redis/<redis_key>", methods=["GET"])
+def get_redis_data(redis_key):
+    service_invite_data = redis_store.raw_get(redis_key)
+    # We can't log this because key may contain PII (email address)
+    if service_invite_data is None:
+        raise Exception("No service invite data")
+    else:
+        service_invite_data = service_invite_data.decode("utf8")
+    return jsonify(json.dumps(service_invite_data)), 200

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -226,7 +226,7 @@ def validate_service_invitation_token(token):
 
 
 @service_invite.route("/service/invite/redis/<redis_key>", methods=["GET"])
-def get_redis_data(redis_key):
+def get_service_invite_data(redis_key):
     service_invite_data = redis_store.raw_get(redis_key)
     # We can't log this because key may contain PII (email address)
     if service_invite_data is None:

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -233,4 +233,4 @@ def get_redis_data(redis_key):
         raise Exception("No service invite data")
     else:
         service_invite_data = service_invite_data.decode("utf8")
-    return jsonify(json.dumps(service_invite_data)), 200
+    return jsonify(service_invite_data), 200

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -400,33 +400,32 @@ def test_get_invited_user_404s_if_invite_doesnt_exist(
     assert json_resp["result"] == "error"
 
 
-def test_get_service_invite_data_with_invite(
-    admin_request,
-    mocker
-):
-    redis_key =  "service-invite-j.k@fake.gov"
-    expected_user_data = b'{"from_user_id": ["7480cdcf-fa31-42b8-a4bf-2cd4d7a9b4f4"], "service_id": "721b0aa6-2447-4bcd-91fc-26d576f2bbff", "permissions": ["manage_api_keys"], "folder_permissions": []}' # noqa
+def test_get_service_invite_data_with_invite(admin_request, mocker):
+    redis_key = "service-invite-j.k@fake.gov"
+    expected_user_data = b'{"from_user_id": ["7480cdcf-fa31-42b8-a4bf-2cd4d7a9b4f4"], "service_id": "721b0aa6-2447-4bcd-91fc-26d576f2bbff", "permissions": ["manage_api_keys"], "folder_permissions": []}'  # noqa
     expected_status = 200
 
-    mocker.patch("app.service_invite.rest.redis_store.raw_get", return_value=expected_user_data)
-    json_resp = json.loads(admin_request.get(
-        "service_invite.get_service_invite_data",
-        redis_key=redis_key,
-        _expected_status=expected_status,
-    ))
+    mocker.patch(
+        "app.service_invite.rest.redis_store.raw_get", return_value=expected_user_data
+    )
+    json_resp = json.loads(
+        admin_request.get(
+            "service_invite.get_service_invite_data",
+            redis_key=redis_key,
+            _expected_status=expected_status,
+        )
+    )
     assert json_resp["permissions"] == ["manage_api_keys"]
 
 
-def test_get_service_invite_data_without_invite(
-    admin_request,
-    mocker
-):
-    redis_key =  "service-invite-j.k@fake.gov"
-
+def test_get_service_invite_data_without_invite(admin_request, mocker):
+    redis_key = "service-invite-j.k@fake.gov"
 
     mocker.patch("app.service_invite.rest.redis_store.raw_get", return_value=None)
-    with pytest.raises(Exception):
-        json_resp = json.loads(admin_request.get(
-            "service_invite.get_service_invite_data",
-            redis_key=redis_key,
-        ))
+    with pytest.raises(BaseException, match="No service invite data"):
+        json.loads(
+            admin_request.get(
+                "service_invite.get_service_invite_data",
+                redis_key=redis_key,
+            )
+        )

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -398,3 +398,35 @@ def test_get_invited_user_404s_if_invite_doesnt_exist(
         _expected_status=404,
     )
     assert json_resp["result"] == "error"
+
+
+def test_get_service_invite_data_with_invite(
+    admin_request,
+    mocker
+):
+    redis_key =  "service-invite-j.k@fake.gov"
+    expected_user_data = b'{"from_user_id": ["7480cdcf-fa31-42b8-a4bf-2cd4d7a9b4f4"], "service_id": "721b0aa6-2447-4bcd-91fc-26d576f2bbff", "permissions": ["manage_api_keys"], "folder_permissions": []}' # noqa
+    expected_status = 200
+
+    mocker.patch("app.service_invite.rest.redis_store.raw_get", return_value=expected_user_data)
+    json_resp = json.loads(admin_request.get(
+        "service_invite.get_service_invite_data",
+        redis_key=redis_key,
+        _expected_status=expected_status,
+    ))
+    assert json_resp["permissions"] == ["manage_api_keys"]
+
+
+def test_get_service_invite_data_without_invite(
+    admin_request,
+    mocker
+):
+    redis_key =  "service-invite-j.k@fake.gov"
+
+
+    mocker.patch("app.service_invite.rest.redis_store.raw_get", return_value=None)
+    with pytest.raises(Exception):
+        json_resp = json.loads(admin_request.get(
+            "service_invite.get_service_invite_data",
+            redis_key=redis_key,
+        ))


### PR DESCRIPTION
## Description

Add an API to return the service invite data from the API server's redis cache.  Add a couple tests as well.

## Security Considerations

N/A