### PR TITLE
Jskinne3 terraform cloudgov 1.0.0

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -3,35 +3,32 @@ locals {
   cf_space_name    = "notify-sandbox"
   env              = "sandbox"
   app_name         = "notify-api"
-  recursive_delete = true
+  recursive_delete = true # deprecated, still used in shared modules
 }
 
 module "database" {
-  source = "github.com/18f/terraform-cloudgov//database?ref=v0.7.1"
+  source = "github.com/18f/terraform-cloudgov//database?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   name             = "${local.app_name}-rds-${local.env}"
-  recursive_delete = local.recursive_delete
   rds_plan_name    = "micro-psql"
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v0.9.1"
+  source = "github.com/18f/terraform-cloudgov//redis?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   name             = "${local.app_name}-redis-${local.env}"
-  recursive_delete = local.recursive_delete
   redis_plan_name  = "redis-dev"
 }
 
 module "csv_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.9.1"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
-  recursive_delete = local.recursive_delete
   name             = "${local.app_name}-csv-upload-bucket-${local.env}"
 }
 

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "database" {
-  source = "github.com/18f/terraform-cloudgov//database?ref=v1.0.0"
+  source = "github.com/GSA-TTS/terraform-cloudgov//database?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -16,7 +16,7 @@ module "database" {
 }
 
 module "redis" {
-  source = "github.com/18f/terraform-cloudgov//redis?ref=v1.0.0"
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
@@ -25,7 +25,7 @@ module "redis" {
 }
 
 module "csv_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v1.0.0"
+  source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name


### PR DESCRIPTION
Upgrade to [version 1.0.0](https://github.com/GSA-TTS/terraform-cloudgov/releases/tag/v1.0.0) of terraform-cloudgov module in the sandbox.

This version removes the deprecated `recursive_delete` parameter. The protection this parameter offered will need to be replaced in the future. Before that replacement is created, there's no harm in eliminating the param from the sandbox Terraform code, where deleting was always allowed.