### PR TITLE
API-1044 - Fixing the test to be less fragile.

### DIFF
--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -167,8 +167,7 @@ def test_dao_update_service_sms_sender_switches_default(notify_db_session):
     expected = {("testing", False), ("updated", True)}
     assert len(sms_senders) == 2
     results = {(sender.sms_sender, sender.is_default) for sender in sms_senders}
-    for item in expected:
-        assert item in results
+    assert expected <= results
 
 
 def test_dao_update_service_sms_sender_raises_exception_when_no_default_after_update(

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -159,15 +159,11 @@ def test_dao_update_service_sms_sender_switches_default(notify_db_session):
         is_default=True,
         sms_sender="updated",
     )
-    sms_senders = (
-        ServiceSmsSender.query.filter_by(service_id=service.id)
-        .order_by(ServiceSmsSender.created_at)
-        .all()
-    )
+    sms_senders = ServiceSmsSender.query.filter_by(service_id=service.id).all()
+
     expected = {("testing", False), ("updated", True)}
-    assert len(sms_senders) == 2
     results = {(sender.sms_sender, sender.is_default) for sender in sms_senders}
-    assert expected <= results
+    assert expected == results
 
 
 def test_dao_update_service_sms_sender_raises_exception_when_no_default_after_update(

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -164,11 +164,11 @@ def test_dao_update_service_sms_sender_switches_default(notify_db_session):
         .order_by(ServiceSmsSender.created_at)
         .all()
     )
+    expected = {("testing", False), ("updated", True)}
     assert len(sms_senders) == 2
-    assert sms_senders[0].sms_sender == "testing"
-    assert not sms_senders[0].is_default
-    assert sms_senders[1].sms_sender == "updated"
-    assert sms_senders[1].is_default
+    results = {(sender.sms_sender, sender.is_default) for sender in sms_senders}
+    for item in expected:
+        assert item in results
 
 
 def test_dao_update_service_sms_sender_raises_exception_when_no_default_after_update(


### PR DESCRIPTION
<!--
Please follow the instructions found in this pull request template so that we
have all of the relevant details needed for our work.

At the minimum, please be sure to fill in all sections found below and also do
the following:

- Provide an appropriate and descriptive title for the pull request
- Link the pull request to its corresponding issue (must be done after creating
  the pull request itself)
- Assign yourself as the author
- Attach the appropriate labels to it
- Set it to be on the Notify.gov project board
- Select one or more reviewers from the team or mark the pull request as a draft
  depending on its current state
   - If the pull request is a draft, please be sure to add reviewers once it is
     ready for review and mark it ready for review

For each section, please delete the instructions/sample text (that includes this
text, though it is wrapped in an HTML comment just in case) and put in your own
information.  Thank you!
-->

*A note to PR reviewers: it may be helpful to review our
[code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews)
to know what to keep in mind while reviewing pull requests.*

## Description

The error was apparently caused by the change to the new not-deprecated method for u

Issue: #1044

## Security Considerations

Can't think of any.