### PR TITLE
Add a null_resource with prevent_destroy to Sandbox

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -6,6 +6,13 @@ locals {
   recursive_delete = true # deprecated, still used in shared modules
 }
 
+resource "null_resource" "prevent_destroy" {
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
 module "database" {
   source = "github.com/GSA-TTS/terraform-cloudgov//database?ref=v1.0.0"
 


### PR DESCRIPTION
## Description

My proposal of how to keep ourselves from destroying Terraform resources on accident: a do-nothing resource with `prevent_destroy` in it. Here in the sandbox it is set to `false` because destroying sandbox stuff is OK. In other environments, it will instead be set to `true`.

This is a replacement for the deprecated `recursive_delete` argument deleted in #1052 

## Testing

Does this protected `null_resource` thing really protect all the other items in the module? Or will it only protect the useless `null_resource` itself?

Having tested it, here’s how it behaves:
When `terraform destroy` makes a plan that would have destroyed anything containing `prevent_destroy = true` the command halts with this error:
```
│ Error: Instance cannot be destroyed
│
│   on main.tf line 9:
│    9: resource "null_resource" "prevent_destroy" {
│
│ Resource null_resource.prevent_destroy has lifecycle.prevent_destroy set, but
│ the plan calls for this resource to be destroyed. To avoid this error and
│ continue with the plan, either disable lifecycle.prevent_destroy or reduce
│ the scope of the plan using the -target option.
```
Thus the technique _does_ prevent all resources in the module from being destroyed via the `terraform destroy` command. (When set to `true` which, again, in this case it is not.)

Now, to be clear, there _are_ still ways to circumvent this protection:
* One can still destroy resources with a targeted destroy command
* Deleting a resource block from the code and running `terraform apply` will nix that resource
* Obviously, a developer can flip `prevent_destroy` to `false` and destroy resources
