### PR TITLE
Redis upgrade proposal

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -22,13 +22,27 @@ module "database" {
   rds_plan_name    = "micro-psql"
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 
   cf_org_name      = local.cf_org_name
   cf_space_name    = local.cf_space_name
   name             = "${local.app_name}-redis-${local.env}"
   redis_plan_name  = "redis-dev"
+}
+
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params      = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
 }
 
 module "csv_upload_bucket" {


### PR DESCRIPTION
## Description

Per issue #978 &mdash; A proposal for how we will upgrade Redis from v6.2 to v7.0. This PR describes a new service instance which can then be bound as the primary Redis for the API app. The old instance would be unbound at the command line and, in a future PR, deleted.

The new resource uses a different name. I _think_ that's fine; requires validation in higher environments. (This is just Sandbox!)