### PR TITLE
Demo: Redis upgrade step 1

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -26,6 +26,20 @@ module "redis" {
   redis_plan_name  = "redis-dev"
 }
 
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-dev"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
+}
+
 module "csv_upload_bucket" {
   source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
 

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -16,7 +16,7 @@ module "database" {
   rds_plan_name    = "micro-psql"
 }
 
-module "redis" {
+module "redis" { # default v6.2; delete after v7.0 resource is bound
   source = "github.com/18f/terraform-cloudgov//redis?ref=v0.7.1"
 
   cf_org_name      = local.cf_org_name


### PR DESCRIPTION
## Description

Per issue #978 and proposed solution in PR #1086

Describe a new service instance to be bound as the primary Redis for the Demo environment, upgrading the Redis version. The old instance will be unbound at the command line and, in a future PR, deleted.
* Redis v7.0
* terraform-cloudgov v1.0.1
