### PR TITLE
pin python to 3.12.3

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -9,10 +9,10 @@ runs:
         sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev
-    - name: Set up Python 3.12.2
+    - name: Set up Python 3.12.3
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12.2"
+        python-version: "3.12.3"
     - name: Install poetry
       shell: bash
       run: pip install --upgrade poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -4747,5 +4747,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "==3.12.2"
-content-hash = "baa97f6f154c63af1c9a727fc8245a36e182190eaa65c77ebd95effc693e576c"
+python-versions = "^3.12.2"
+content-hash = "122fe6459adad8b8105d12739e4db159ae39fc32e969d02c7c24436ed3fb85b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 
 [tool.poetry.dependencies]
-python = "==3.12.3"
+python = "^3.12.2"
 alembic = "==1.13.1"
 amqp = "==5.2.0"
 beautifulsoup4 = "==4.12.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 
 [tool.poetry.dependencies]
-python = "==3.12.2"
+python = "==3.12.3"
 alembic = "==1.13.1"
 amqp = "==5.2.0"
 beautifulsoup4 = "==4.12.3"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.12.x
+python-3.12.3


### PR DESCRIPTION
## Description

I can't run `make bootstrap` locally if the pyproject.toml is set to "==3.12.3" without upgrading to 3.12.3 in my local environment, so I have set the pyproject.toml to "^3.12.2" and the action is essentially ==3.12.3

## Security Considerations

N/A