### PR TITLE
Upgrade tj-actions from v41 to v44 in Staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Check for changes to Terraform
       id: changed-terraform-files
-      uses: tj-actions/changed-files@v41
+      uses: tj-actions/changed-files@v44
       with:
         files: |
           terraform/staging
@@ -81,7 +81,7 @@ jobs:
 
     - name: Check for changes to templates.json
       id: changed-templates
-      uses: tj-actions/changed-files@v41
+      uses: tj-actions/changed-files@v44
       with:
         files: |
           app/config_files/templates.json
@@ -91,7 +91,7 @@ jobs:
 
     - name: Check for changes to egress config
       id: changed-egress-config
-      uses: tj-actions/changed-files@v41
+      uses: tj-actions/changed-files@v44
       with:
         files: |
           deploy-config/egress_proxy/notify-api-staging.*.acl


### PR DESCRIPTION
Update the GitHub action [tj-actions/changed-files] from v41 to v44

This is an attempt to fix a problem in which `terraform init` and `apply` are being skipped in [a context where](https://github.com/GSA/notifications-api/actions/runs/9665716279/job/26663508161) we don't think they should be skipped.

The action [has made modifications](https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#4300---2024-03-13) to its `any_changed` function which [we use](https://github.com/GSA/notifications-api/blob/cac5ef7b34f912a5f6f54ebcea91e1ff698b624c/.github/workflows/deploy.yml#L40) to determine when these Terraform commands. So, perhaps upgrading will correct the function's behavior.

This PR only applies to staging -- the staging workflow has the generic name `deploy.yml`. After it is validated, the same should be extended to the prod and demo environments.