### PR TITLE
Staging: Redis upgrade final step

### DIFF
--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -21,15 +21,6 @@ module "database" {
   rds_plan_name = "micro-psql"
 }
 
-module "redis" { # default v6.2; delete after v7.0 resource is bound
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-dev"
-}
-
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -21,15 +21,6 @@ module "database" {
   rds_plan_name = "micro-psql"
 }
 
-module "redis" { # default v6.2; delete after v7.0 resource is bound
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-dev"
-}
-
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 


### PR DESCRIPTION
The sequel to #1104:

Remove old v6.2 Redis instance, now that new instance has been created and bound, from the Staging and Sandbox environments 

### Note
these are the commands that were used to unbind the old and bind the new:
```
cf unbind-service notify-api-staging notify-api-redis-staging
cf bind-service notify-api-staging notify-api-redis-v70-staging
cf restart notify-api-staging
```