### PR TITLE
Update name of Redis to include v70

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ applications:
 
     services:
       - notify-api-rds-((env))
-      - notify-api-redis-((env))
+      - notify-api-redis-v70-((env))
       - notify-api-csv-upload-bucket-((env))
       - name: notify-api-ses-((env))
         parameters:


### PR DESCRIPTION
Changes the name of the Redis instance we are using to an updated name corresponding to a version upgrade. This will unbind the old version and bind the new. This applies to **all** environments, because they share a single manifest file.

We think this will work without manually using the `cf unbind-service` and `cf bind-service` commands.

I considered undoing PR #1116 because it is a step that should occur _after_ this one. But it appears the deployment pipeline is refusing to apply that PR while the old Redis is still bound, and thus, undoing it in source control is not necessary. It should take effect after this one.