### PR TITLE
Temp switch manifest to old Redis name, delete new Redis block

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ applications:
 
     services:
       - notify-api-rds-((env))
-      - notify-api-redis-v70-((env))
+      - notify-api-redis-((env))
       - notify-api-csv-upload-bucket-((env))
       - name: notify-api-ses-((env))
         parameters:

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,20 +30,6 @@ module "redis" { # default v6.2; delete after v7.0 resource is bound
   redis_plan_name = "redis-3node-large"
 }
 
-module "redis-v70" {
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-v70-${local.env}"
-  redis_plan_name = "redis-dev"
-  json_params = jsonencode(
-    {
-      "engineVersion" : "7.0",
-    }
-  )
-}
-
 module "csv_upload_bucket" {
   source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -21,6 +21,15 @@ module "database" {
   rds_plan_name = "micro-psql"
 }
 
+module "redis" { # default v6.2; delete after v7.0 resource is bound
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-${local.env}"
+  redis_plan_name = "redis-dev"
+}
+
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 


### PR DESCRIPTION
I accidentally created our new v7.0 Redis in prod without the correct plan! So:
* Switching binding (via manifest file) back to old Redis
* Deleting new Redis

This will allow it to be replaced in a subsequent PR