### PR TITLE
Restore Redis instance at v7.0

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ applications:
 
     services:
       - notify-api-rds-((env))
-      - notify-api-redis-((env))
+      - notify-api-redis-v70-((env))
       - notify-api-csv-upload-bucket-((env))
       - name: notify-api-ses-((env))
         parameters:

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,6 +30,20 @@ module "redis" { # default v6.2; delete after v7.0 resource is bound
   redis_plan_name = "redis-3node-large"
 }
 
+module "redis-v70" {
+  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
+
+  cf_org_name     = local.cf_org_name
+  cf_space_name   = local.cf_space_name
+  name            = "${local.app_name}-redis-v70-${local.env}"
+  redis_plan_name = "redis-3node-large"
+  json_params = jsonencode(
+    {
+      "engineVersion" : "7.0",
+    }
+  )
+}
+
 module "csv_upload_bucket" {
   source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 


### PR DESCRIPTION
Restore Redis block that was deleted in https://github.com/GSA/notifications-api/pull/1123 but with the correct plan name