### PR TITLE
Removed old redis from terraform.

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -21,15 +21,6 @@ module "database" {
   rds_plan_name = "micro-psql"
 }
 
-module "redis" { # default v6.2; delete after v7.0 resource is bound
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-dev"
-}
-
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -21,15 +21,6 @@ module "database" {
   rds_plan_name = "small-psql-redundant"
 }
 
-module "redis" { # default v6.2; delete after v7.0 resource is bound
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-3node-large"
-}
-
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -21,15 +21,6 @@ module "database" {
   rds_plan_name = "micro-psql"
 }
 
-module "redis" { # default v6.2; delete after v7.0 resource is bound
-  source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
-
-  cf_org_name     = local.cf_org_name
-  cf_space_name   = local.cf_space_name
-  name            = "${local.app_name}-redis-${local.env}"
-  redis_plan_name = "redis-dev"
-}
-
 module "redis-v70" {
   source = "github.com/GSA-TTS/terraform-cloudgov//redis?ref=v1.0.0"
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our
[code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews)
to know what to keep in mind while reviewing pull requests.*

## Description

Removing the old, inept version of redis from terraform, as everything is pointing to the new shiny v70.

This is the final part of https://github.com/GSA/notifications-api/issues/978. 🎉 

## Security Considerations

- We don't want to leave old, unsupported service instances lying around.