### PR TITLE
Upgrade terraform-cloudgov, remove recursive_delete in dev module

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -6,12 +6,11 @@ locals {
 }
 
 module "csv_upload_bucket" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
+  source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 
-  cf_org_name      = local.cf_org_name
-  cf_space_name    = local.cf_space_name
-  recursive_delete = local.recursive_delete
-  name             = "${var.username}-csv-upload-bucket"
+  cf_org_name   = local.cf_org_name
+  cf_space_name = local.cf_space_name
+  name          = "${var.username}-csv-upload-bucket"
 }
 resource "cloudfoundry_service_key" "csv_key" {
   name             = local.key_name


### PR DESCRIPTION
In local development module:
* Upgrade terraform-cloudgov to v1.0.0 (the latest)
* remove recursive_delete

A fraternal twin of PR https://github.com/GSA/notifications-admin/pull/1742
Both are part of issue https://github.com/GSA/notifications-api/issues/1139