### PR TITLE
raise exception if phone number doesn't match

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -103,12 +103,7 @@ def send_sms_to_provider(notification):
                         f"The recipient for (Service ID: {si}; Job ID: {ji}; Job Row Number {jrn} was not found."
                     )
 
-                possible_senders = dao_get_sms_senders_by_service_id(
-                    notification.service_id
-                )
-                sender_numbers = []
-                for possible_sender in possible_senders:
-                    sender_numbers.append(possible_sender.sms_sender)
+                sender_numbers = get_sender_numbers(notification)
                 if notification.reply_to_text not in sender_numbers:
                     raise ValueError(
                         f"{notification.reply_to_text} not in {sender_numbers} #notify-admin-1701"
@@ -141,6 +136,14 @@ def send_sms_to_provider(notification):
                 notification.billable_units = template.fragment_count
                 update_notification_to_sending(notification, provider)
     return message_id
+
+
+def get_sender_numbers(notification):
+    possible_senders = dao_get_sms_senders_by_service_id(notification.service_id)
+    sender_numbers = []
+    for possible_sender in possible_senders:
+        sender_numbers.append(possible_sender.sms_sender)
+    return sender_numbers
 
 
 def send_email_to_provider(notification):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -330,6 +330,7 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
         template=template,
     )
     db_notification.personalisation = {"misc": placeholder}
+    db_notification.reply_to_text = 'testing'
 
     mocker.patch("app.aws_sns_client.send_sms")
 
@@ -621,6 +622,7 @@ def test_should_update_billable_units_and_status_according_to_research_mode_and_
         billable_units=0,
         status=NotificationStatus.CREATED,
         key_type=key_type,
+        reply_to_text='testing',
     )
     mocker.patch("app.aws_sns_client.send_sms")
     mocker.patch(
@@ -784,7 +786,7 @@ def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_te
     )
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
-        template=sample_template, to_field="+12028675309", normalised_to="2028675309"
+        template=sample_template, to_field="+12028675309", normalised_to="2028675309", reply_to_text='testing'
     )
 
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
@@ -860,7 +862,7 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
 
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
-        template=sample_template, to_field="+447700900855", normalised_to="447700900855"
+        template=sample_template, to_field="+447700900855", normalised_to="447700900855", reply_to_text='testing'
     )
 
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -318,6 +318,9 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     # é, o, and u are in GSM.
     # ī, grapes, tabs, zero width space and ellipsis are not
     # ó isn't in GSM, but it is in the welsh alphabet so will still be sent
+    mocker.patch(
+        "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
+    )
     msg = "a é ī o u 🍇 foo\tbar\u200bbaz((misc))…"
     placeholder = "∆∆∆abc"
     gsm_message = "?ódz Housing Service: a é i o u ? foo barbaz???abc..."
@@ -609,6 +612,10 @@ def __update_notification(notification_to_update, research_mode, expected_status
 def test_should_update_billable_units_and_status_according_to_research_mode_and_key_type(
     sample_template, mocker, research_mode, key_type, billable_units, expected_status
 ):
+
+    mocker.patch(
+        "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
+    )
     notification = create_notification(
         template=sample_template,
         billable_units=0,
@@ -771,6 +778,10 @@ def test_send_email_to_provider_uses_reply_to_from_notification(
 
 
 def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_template):
+
+    mocker.patch(
+        "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
+    )
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
         template=sample_template, to_field="+12028675309", normalised_to="2028675309"
@@ -826,6 +837,10 @@ def test_send_email_to_provider_should_user_normalised_to(
 def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     mocker, client, sample_template
 ):
+
+    mocker.patch(
+        "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
+    )
     from app.schemas import service_schema, template_schema
 
     service_dict = service_schema.dump(sample_template.service)


### PR DESCRIPTION
## Description

We can check the sender that the notification knows about against the list of available senders for a given service.  If the notification's sender is not on the list, we can raise an exception.

## Security Considerations

N/A
