### PR TITLE
fix sort on download all users

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -253,6 +253,6 @@ def dao_report_users():
     inner join user_to_service on users.id=user_to_service.user_id
     inner join services on services.id=user_to_service.service_id
     where services.name not like '_archived%'
-    order by services.name asc, users.name asc
+    order by users.name asc
     """
     return db.session.execute(text(sql))


### PR DESCRIPTION
## Description

The double sort kind of made sense to me in theory, but for some reason it's delivering results different from what I would expect to see.   And so, in thinking more about it, I realized that only developers are going to have users that are part of ten, twenty, thirty services.  All our customers have exactly one service so the sort would not be doing anything useful, anyway.

## Security Considerations

N/A