### PR TITLE
Adjust staging and demo worker instance settings

### DIFF
--- a/deploy-config/demo.yml
+++ b/deploy-config/demo.yml
@@ -1,7 +1,7 @@
 env: demo
 web_instances: 2
 web_memory: 1G
-worker_instances: 1
+worker_instances: 2
 worker_memory: 512M
 scheduler_memory: 256M
 public_api_route: notify-api-demo.app.cloud.gov

--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -1,8 +1,8 @@
 env: staging
 web_instances: 2
 web_memory: 1G
-worker_instances: 1
-worker_memory: 512M
+worker_instances: 2
+worker_memory: 1G
 scheduler_memory: 256M
 public_api_route: notify-api-staging.app.cloud.gov
 admin_base_url: https://notify-staging.app.cloud.gov


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a bit more memory to the staging worker instance, and it bumps the number of worker instances to 2 in staging and demo.

## Security Considerations

* This addresses a few memory limits we've been hitting in staging with our API while we're testing the site and trying to replicate a heavier amount of usage.