### PR TITLE
Change phone number in Notify.gov w/o entering password

### DIFF
--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -49,7 +49,6 @@ class AwsSnsClient(SmsClient):
 
     def send_sms(self, to, content, reference, sender=None, international=False):
         matched = False
-        print(hilite(f"TO {to}"))
         for match in phonenumbers.PhoneNumberMatcher(to, "US"):
             matched = True
             to = phonenumbers.format_number(

--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -2,7 +2,6 @@ import os
 import re
 from time import monotonic
 
-from app.utils import hilite
 import botocore
 import phonenumbers
 from boto3 import client
@@ -10,6 +9,7 @@ from boto3 import client
 from app.clients import AWS_CLIENT_CONFIG
 from app.clients.sms import SmsClient
 from app.cloudfoundry_config import cloud_config
+from app.utils import hilite
 
 
 class AwsSnsClient(SmsClient):

--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -9,7 +9,6 @@ from boto3 import client
 from app.clients import AWS_CLIENT_CONFIG
 from app.clients.sms import SmsClient
 from app.cloudfoundry_config import cloud_config
-from app.utils import hilite
 
 
 class AwsSnsClient(SmsClient):

--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -2,6 +2,7 @@ import os
 import re
 from time import monotonic
 
+from app.utils import hilite
 import botocore
 import phonenumbers
 from boto3 import client
@@ -48,7 +49,7 @@ class AwsSnsClient(SmsClient):
 
     def send_sms(self, to, content, reference, sender=None, international=False):
         matched = False
-
+        print(hilite(f"TO {to}"))
         for match in phonenumbers.PhoneNumberMatcher(to, "US"):
             matched = True
             to = phonenumbers.format_number(

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -80,20 +80,15 @@ def send_sms_to_provider(notification):
 
                 # We start by trying to get the phone number from a job in s3.  If we fail, we assume
                 # the phone number is for the verification code on login, which is not a job.
-                print(f"IN THE TRY AND JOB_ID is {notification.job_id}")
                 recipient = None
                 # It is our 2facode, maybe
                 if notification.job_id is None:
-                    print(f"IN THE IF AND WE ARE GOING TO GET THE 2FA KEY")
                     key = f"2facode-{notification.id}".replace(" ", "")
-                    print(hilite(f"KEY IS SEND_TO_PROVIDERS IS {key}"))
                     recipient = redis_store.get(key)
                     if recipient:
                         recipient = recipient.decode("utf-8")
 
-                    print(hilite(f"RECIPIENT IN SEND TO PROVIDERS IS {recipient}"))
                 else:
-                    print(f"IN THE ELSE AND WE ARE GOING TO GET FROM S3")
                     try:
                         recipient = get_phone_number_from_s3(
                             notification.service_id,
@@ -103,9 +98,7 @@ def send_sms_to_provider(notification):
                     except Exception:
                         # It is our 2facode, maybe
                         key = f"2facode-{notification.id}".replace(" ", "")
-                        print(hilite(f"KEY IS SEND_TO_PROVIDERS IS {key}"))
                         recipient = redis_store.get(key)
-                        print(hilite(f"RECIPIENT IN SEND TO PROVIDERS IS {recipient}"))
 
                         if recipient:
                             recipient = recipient.decode("utf-8")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -80,20 +80,35 @@ def send_sms_to_provider(notification):
 
                 # We start by trying to get the phone number from a job in s3.  If we fail, we assume
                 # the phone number is for the verification code on login, which is not a job.
+                print(f"IN THE TRY AND JOB_ID is {notification.job_id}")
                 recipient = None
-                try:
-                    recipient = get_phone_number_from_s3(
-                        notification.service_id,
-                        notification.job_id,
-                        notification.job_row_number,
-                    )
-                except Exception:
-                    # It is our 2facode, maybe
+                # It is our 2facode, maybe
+                if notification.job_id is None:
+                    print(f"IN THE IF AND WE ARE GOING TO GET THE 2FA KEY")
                     key = f"2facode-{notification.id}".replace(" ", "")
+                    print(hilite(f"KEY IS SEND_TO_PROVIDERS IS {key}"))
                     recipient = redis_store.get(key)
-
                     if recipient:
                         recipient = recipient.decode("utf-8")
+
+                    print(hilite(f"RECIPIENT IN SEND TO PROVIDERS IS {recipient}"))
+                else:
+                    print(f"IN THE ELSE AND WE ARE GOING TO GET FROM S3")
+                    try:
+                        recipient = get_phone_number_from_s3(
+                            notification.service_id,
+                            notification.job_id,
+                            notification.job_row_number,
+                        )
+                    except Exception:
+                        # It is our 2facode, maybe
+                        key = f"2facode-{notification.id}".replace(" ", "")
+                        print(hilite(f"KEY IS SEND_TO_PROVIDERS IS {key}"))
+                        recipient = redis_store.get(key)
+                        print(hilite(f"RECIPIENT IN SEND TO PROVIDERS IS {recipient}"))
+
+                        if recipient:
+                            recipient = recipient.decode("utf-8")
 
                 if recipient is None:
                     si = notification.service_id

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import suppress
 from urllib import parse
 
 from cachetools import TTLCache, cached
@@ -129,7 +130,7 @@ def send_sms_to_provider(notification):
 def _get_verify_code(notification):
     key = f"2facode-{notification.id}".replace(" ", "")
     recipient = redis_store.get(key)
-    if recipient:
+    with suppress(AttributeError):
         recipient = recipient.decode("utf-8")
     return recipient
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -307,9 +307,7 @@ def send_user_2fa_code(user_id, code_type):
 
 
 def send_user_sms_code(user_to_send_to, data):
-    print(hilite("SEND_USER_SMS_CODE"))
     recipient = data.get("to") or user_to_send_to.mobile_number
-    print(hilite(f"RECIPIENT {recipient}"))
     secret_code = create_secret_code()
     personalisation = {"verify_code": secret_code}
 
@@ -373,7 +371,6 @@ def create_2fa_code(
     key = f"2facode-{saved_notification.id}".replace(" ", "")
     recipient = str(recipient)
     redis_store.set(key, recipient, ex=60 * 60)
-    print(hilite(f"SET REDIS 2facode-{saved_notification.id} to {recipient}"))
 
     # Assume that we never want to observe the Notify service's research mode
     # setting for this notification - we still need to be able to log into the

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -53,7 +53,7 @@ from app.user.users_schema import (
     post_verify_code_schema,
     post_verify_webauthn_schema,
 )
-from app.utils import hilite, url_with_token, utc_now
+from app.utils import url_with_token, utc_now
 from notifications_utils.recipients import is_us_phone_number, use_numeric_sender
 
 user_blueprint = Blueprint("user", __name__)

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -53,7 +53,7 @@ from app.user.users_schema import (
     post_verify_code_schema,
     post_verify_webauthn_schema,
 )
-from app.utils import url_with_token, utc_now
+from app.utils import hilite, url_with_token, utc_now
 from notifications_utils.recipients import is_us_phone_number, use_numeric_sender
 
 user_blueprint = Blueprint("user", __name__)
@@ -307,8 +307,9 @@ def send_user_2fa_code(user_id, code_type):
 
 
 def send_user_sms_code(user_to_send_to, data):
+    print(hilite("SEND_USER_SMS_CODE"))
     recipient = data.get("to") or user_to_send_to.mobile_number
-
+    print(hilite(f"RECIPIENT {recipient}"))
     secret_code = create_secret_code()
     personalisation = {"verify_code": secret_code}
 
@@ -372,6 +373,7 @@ def create_2fa_code(
     key = f"2facode-{saved_notification.id}".replace(" ", "")
     recipient = str(recipient)
     redis_store.set(key, recipient, ex=60 * 60)
+    print(hilite(f"SET REDIS 2facode-{saved_notification.id} to {recipient}"))
 
     # Assume that we never want to observe the Notify service's research mode
     # setting for this notification - we still need to be able to log into the

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -117,6 +117,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     sample_email_template_with_html, mocker
 ):
 
+    mock_redis = mocker.patch("app.delivery.send_to_providers.redis_store")
     utf8_encoded_email = "jo.smith@example.com".encode("utf-8")
     mock_redis.get.return_value = utf8_encoded_email
     email = utf8_encoded_email

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -75,6 +75,8 @@ def test_provider_to_use_raises_if_no_active_providers(
 def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
     sample_sms_template_with_html, mocker
 ):
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     db_notification = create_notification(
         template=sample_sms_template_with_html,
         personalisation={},
@@ -213,6 +215,8 @@ def test_should_not_send_sms_message_when_service_is_inactive_notification_is_in
 def test_send_sms_should_use_template_version_from_notification_not_latest(
     sample_template, mocker
 ):
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     db_notification = create_notification(
         template=sample_template,
         to_field="2028675309",
@@ -614,6 +618,7 @@ def test_should_update_billable_units_and_status_according_to_research_mode_and_
     sample_template, mocker, research_mode, key_type, billable_units, expected_status
 ):
 
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )
@@ -725,6 +730,8 @@ def test_should_send_sms_to_international_providers(
 def test_should_handle_sms_sender_and_prefix_message(
     mocker, sms_sender, prefix_sms, expected_sender, expected_content, notify_db_session
 ):
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch("app.aws_sns_client.send_sms")
     service = create_service_with_defined_sms_sender(
         sms_sender_value=sms_sender, prefix_sms=prefix_sms

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -322,6 +322,8 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     # é, o, and u are in GSM.
     # ī, grapes, tabs, zero width space and ellipsis are not
     # ó isn't in GSM, but it is in the welsh alphabet so will still be sent
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )
@@ -356,6 +358,8 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
 def test_send_sms_should_use_service_sms_sender(
     sample_service, sample_template, mocker
 ):
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch("app.aws_sns_client.send_sms")
 
     sms_sender = create_service_sms_sender(
@@ -681,6 +685,8 @@ def test_should_set_notification_billable_units_and_reduces_provider_priority_if
 def test_should_send_sms_to_international_providers(
     sample_template, sample_user, mocker
 ):
+
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch("app.aws_sns_client.send_sms")
 
     notification_international = create_notification(
@@ -788,6 +794,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(
 
 def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_template):
 
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )
@@ -850,6 +857,7 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     mocker, client, sample_template
 ):
 
+    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -76,11 +76,10 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
     sample_sms_template_with_html, mocker
 ):
 
-    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_code", return_value=None)
     db_notification = create_notification(
         template=sample_sms_template_with_html,
         personalisation={},
-        job_id="myjobid",
         status=NotificationStatus.CREATED,
         reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
     )
@@ -117,7 +116,9 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
 def test_should_send_personalised_template_to_correct_email_provider_and_persist(
     sample_email_template_with_html, mocker
 ):
-    mock_redis = mocker.patch("app.delivery.send_to_providers.redis_store")
+    mock_redis = mocker.patch(
+        "app.delivery.send_to_providers._get_verify_code", return_value=None
+    )
     utf8_encoded_email = "jo.smith@example.com".encode("utf-8")
     mock_redis.get.return_value = utf8_encoded_email
     email = utf8_encoded_email
@@ -224,7 +225,6 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
         status=NotificationStatus.CREATED,
         reply_to_text=sample_template.service.get_default_sms_sender(),
         normalised_to="2028675309",
-        job_id="myjobid",
     )
 
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
@@ -694,7 +694,6 @@ def test_should_send_sms_to_international_providers(
     notification_international = create_notification(
         template=sample_template,
         to_field="+6011-17224412",
-        job_id="myjobid",
         personalisation={"name": "Jo"},
         status=NotificationStatus.CREATED,
         international=True,
@@ -804,7 +803,6 @@ def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_te
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
         template=sample_template,
-        job_id="myjobid",
         to_field="+12028675309",
         normalised_to="2028675309",
         reply_to_text="testing",
@@ -861,7 +859,7 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     mocker, client, sample_template
 ):
 
-    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_coe", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )
@@ -885,7 +883,6 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
         template=sample_template,
-        job_id="myjobid",
         to_field="+447700900855",
         normalised_to="447700900855",
         reply_to_text="testing",

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -218,7 +218,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
     sample_template, mocker
 ):
 
-    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_code", return_value=None)
     db_notification = create_notification(
         template=sample_template,
         to_field="2028675309",
@@ -688,7 +688,7 @@ def test_should_send_sms_to_international_providers(
     sample_template, sample_user, mocker
 ):
 
-    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_code", return_value=None)
     mocker.patch("app.aws_sns_client.send_sms")
 
     notification_international = create_notification(
@@ -796,7 +796,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(
 
 def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_template):
 
-    mocker.patch("app.delivery.send_to_providers.redis_store", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_code", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )
@@ -859,7 +859,7 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     mocker, client, sample_template
 ):
 
-    mocker.patch("app.delivery.send_to_providers._get_verify_coe", return_value=None)
+    mocker.patch("app.delivery.send_to_providers._get_verify_code", return_value=None)
     mocker.patch(
         "app.delivery.send_to_providers.get_sender_numbers", return_value=["testing"]
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -116,9 +116,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
 def test_should_send_personalised_template_to_correct_email_provider_and_persist(
     sample_email_template_with_html, mocker
 ):
-    mock_redis = mocker.patch(
-        "app.delivery.send_to_providers._get_verify_code", return_value=None
-    )
+
     utf8_encoded_email = "jo.smith@example.com".encode("utf-8")
     mock_redis.get.return_value = utf8_encoded_email
     email = utf8_encoded_email

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -80,6 +80,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
     db_notification = create_notification(
         template=sample_sms_template_with_html,
         personalisation={},
+        job_id="myjobid",
         status=NotificationStatus.CREATED,
         reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
     )
@@ -223,6 +224,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
         status=NotificationStatus.CREATED,
         reply_to_text=sample_template.service.get_default_sms_sender(),
         normalised_to="2028675309",
+        job_id="myjobid",
     )
 
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
@@ -692,6 +694,7 @@ def test_should_send_sms_to_international_providers(
     notification_international = create_notification(
         template=sample_template,
         to_field="+6011-17224412",
+        job_id="myjobid",
         personalisation={"name": "Jo"},
         status=NotificationStatus.CREATED,
         international=True,
@@ -801,6 +804,7 @@ def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_te
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
         template=sample_template,
+        job_id="myjobid",
         to_field="+12028675309",
         normalised_to="2028675309",
         reply_to_text="testing",
@@ -881,6 +885,7 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     send_mock = mocker.patch("app.aws_sns_client.send_sms")
     notification = create_notification(
         template=sample_template,
+        job_id="myjobid",
         to_field="+447700900855",
         normalised_to="447700900855",
         reply_to_text="testing",


### PR DESCRIPTION
## Description

Previously when the user wanted to change their phone number in the UI, we prompted for their password.  However, now the whole concept of password belongs to login.gov, so we cannot prompt for that.  Eliminate the password step, but there is still the verify code step.  So user will change their phone number, but they have to have access to the new phone number in order to effect the change.

## Security Considerations

N/A