### PR TITLE
Fix job.created_at time if necessary

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -153,11 +153,11 @@ def dao_create_job(job):
         current_app.logger.error(
             "#notify-admin-1859 Something is wrong with job.created_at!  Try resetting it"
         )
-        job.created_at = now_time
-        dao_update_job(job)
-        current_app.logger.error(
-            f"#notify-admin-1859 Job created_at reset to {job.created_at}"
-        )
+        # job.created_at = now_time
+        # dao_update_job(job)
+        # current_app.logger.error(
+        #    f"#notify-admin-1859 Job created_at reset to {job.created_at}"
+        # )
 
 
 def dao_update_job(job):

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -151,8 +151,9 @@ def dao_create_job(job):
     )
     if diff_time.total_seconds() > 120:  # It should be only a few seconds diff at most
         current_app.logger.error(
-            "#notify-admin-1859 Something is wrong with job.created_at!  Try resetting it"
+            "#notify-admin-1859 Something is wrong with job.created_at!"
         )
+        raise Exception("#notify-admin-1859 Something is wrong with job.created_at!")
         # job.created_at = now_time
         # dao_update_job(job)
         # current_app.logger.error(

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -13,7 +13,7 @@ from app.models import (
     ServiceDataRetention,
     Template,
 )
-from app.utils import hilite, midnight_n_days_ago, utc_now
+from app.utils import midnight_n_days_ago, utc_now
 
 
 def dao_get_notification_outcomes_for_job(service_id, job_id):
@@ -152,7 +152,7 @@ def dao_create_job(job):
     )
     if diff_time.total_seconds() > 120:  # It should be only a few seconds diff at most
         current_app.logger.error(
-            f"#notify-admin-1859 Something is wrong with job.created_at!  Try resetting it"
+            "#notify-admin-1859 Something is wrong with job.created_at!  Try resetting it"
         )
         job.created_at = now_time
         dao_update_job(job)

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import timedelta
 
@@ -149,16 +150,16 @@ def dao_create_job(job):
     current_app.logger.info(
         f"#notify-admin-1859 dao_create_job orig created at {orig_time} and now {now_time}"
     )
-    if diff_time.total_seconds() > 120:  # It should be only a few seconds diff at most
+    if diff_time.total_seconds() > 300:  # It should be only a few seconds diff at most
         current_app.logger.error(
             "#notify-admin-1859 Something is wrong with job.created_at!"
         )
-        raise Exception("#notify-admin-1859 Something is wrong with job.created_at!")
-        # job.created_at = now_time
-        # dao_update_job(job)
-        # current_app.logger.error(
-        #    f"#notify-admin-1859 Job created_at reset to {job.created_at}"
-        # )
+        if os.getenv("NOTIFY_ENVIRONMENT") not in ["test"]:
+            job.created_at = now_time
+            dao_update_job(job)
+            current_app.logger.error(
+                f"#notify-admin-1859 Job created_at reset to {job.created_at}"
+            )
 
 
 def dao_update_job(job):

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -144,7 +144,6 @@ def dao_create_job(job):
     # 8/19 yet show a created_at time of 8/16.  This seems to be the only
     # place the created_at value is set so do some double-checking and debugging
     orig_time = job.created_at
-    orig_time = orig_time - timedelta(days=3)
     now_time = utc_now()
     diff_time = now_time - orig_time
     current_app.logger.info(

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -33,7 +33,7 @@ from app.schemas import (
     notifications_filter_schema,
     unarchived_template_schema,
 )
-from app.utils import midnight_n_days_ago, pagination_links
+from app.utils import hilite, midnight_n_days_ago, pagination_links
 
 job_blueprint = Blueprint("job", __name__, url_prefix="/service/<uuid:service_id>/job")
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -33,7 +33,7 @@ from app.schemas import (
     notifications_filter_schema,
     unarchived_template_schema,
 )
-from app.utils import hilite, midnight_n_days_ago, pagination_links
+from app.utils import midnight_n_days_ago, pagination_links
 
 job_blueprint = Blueprint("job", __name__, url_prefix="/service/<uuid:service_id>/job")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2105,13 +2105,9 @@ files = [
     {file = "lxml-5.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:edcfa83e03370032a489430215c1e7783128808fd3e2e0a3225deee278585196"},
     {file = "lxml-5.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28bf95177400066596cdbcfc933312493799382879da504633d16cf60bba735b"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a745cc98d504d5bd2c19b10c79c61c7c3df9222629f1b6210c0368177589fb8"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b590b39ef90c6b22ec0be925b211298e810b4856909c8ca60d27ffbca6c12e6"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b336b0416828022bfd5a2e3083e7f5ba54b96242159f83c7e3eebaec752f1716"},
-    {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:c2faf60c583af0d135e853c86ac2735ce178f0e338a3c7f9ae8f622fd2eb788c"},
     {file = "lxml-5.2.2-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:4bc6cb140a7a0ad1f7bc37e018d0ed690b7b6520ade518285dc3171f7a117905"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7ff762670cada8e05b32bf1e4dc50b140790909caa8303cfddc4d702b71ea184"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:57f0a0bbc9868e10ebe874e9f129d2917750adf008fe7b9c1598c0fbbfdde6a6"},
-    {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a6d2092797b388342c1bc932077ad232f914351932353e2e8706851c870bca1f"},
     {file = "lxml-5.2.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:60499fe961b21264e17a471ec296dcbf4365fbea611bf9e303ab69db7159ce61"},
     {file = "lxml-5.2.2-cp37-cp37m-win32.whl", hash = "sha256:d9b342c76003c6b9336a80efcc766748a333573abf9350f4094ee46b006ec18f"},
     {file = "lxml-5.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b16db2770517b8799c79aa80f4053cd6f8b716f21f8aca962725a9565ce3ee40"},
@@ -2500,6 +2496,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 


### PR DESCRIPTION
## Description

We have some anomaly where the created_at field for jobs is set 3 days in the past (intermittently).  It seems like there is only one place where this happens (dao_create_job()), so add some debugging and a repair attempt and get this up to staging and see what happens.

We have a couple dozen tests using "freeze time" which all break if we try to do the repair, so do a check on what environment we are running in before doing it.

## Security Considerations

N/A