### PR TITLE
fix log formatting

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -160,6 +160,12 @@ class JSONFormatter(BaseJSONFormatter):
         log_record["logType"] = "application"
         try:
             log_record["message"] = log_record["message"].format(**log_record)
-        except (KeyError, IndexError) as e:
-            logger.exception("failed to format log message: {} not found".format(e))
+        except KeyError as e:
+            # We get occasional log messages that are nested dictionaries,
+            # for example, delivery receipts, where the formatting fails
+            # This is not a huge problem, don't dump stack traces into the logs
+            # for it.
+            logger.warning(f"failed to format log message: {e}")
+        except IndexError as e:
+            logger.exception(f"failed to format log message: {e}")
         return log_record


### PR DESCRIPTION
## Description

We do some log formatting to prettify the logs, which is great, but the formatting fails if the log message is a nested dictionary, which it is when we get delivery receipts from AWS.  Which means we are getting a stack trace every time a message is delivered or permanently fails.  This serves no purpose, and doesn't affect logging at all (ie, we still get the delivered/failed message, just with extra unwanted stack traces).

Suppress the stack trace if it is caused by a KeyError.


## Security Considerations

N/A