### PR TITLE
make generate-salt command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,35 +8,9 @@ on:
     branches: [ main ] # Redundant, workflow_run events are only triggered on default branch (`main`)
 
 permissions:
-  checks: write
-  pull-requests: write
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
-  rotate-secret:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Generate new secret value
-        id: generate-secret
-        run: |
-          # Generate a new random secret value
-          NEW_SECRET=$(openssl rand -base64 32)
-          echo "new-secret=$NEW_SECRET" >> $GITHUB_ENV
-      - name: Update GitHub secret
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_SECRET: ${{ env.new-secret }}
-        run: |
-          # Update the secret in the repository
-          curl -X PUT \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/secrets/DANGEROUS_SALT \
-            -d "{\"encrypted_value\":\"$(echo -n $NEW_SECRET | base64)\",\"key_id\":\"$(curl -H 'Authorization: Bearer $GITHUB_TOKEN' https://api.github.com/repos/${{ github.repository }}/actions/secrets/public-key | jq -r '.key_id')\"}"
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
     branches: [ main ] # Redundant, workflow_run events are only triggered on default branch (`main`)
 
 permissions:
+  checks: write
+  pull-requests: write
   contents: write
   actions: write
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -1053,3 +1053,15 @@ def add_test_users_to_db(generate, state, admin):
             platform_admin=admin,
         )
         print(f"{num} {user.email_address} created")
+
+# generate a new salt value
+@notify_command(name="generate-salt")
+def generate_salt():
+    salt = secrets.token_hex(16)
+    # We want to print here.  This value is
+    # generated locally for the developer doing
+    # the salt rotation task, so we don't care if
+    # the task is somehow run on production tier and
+    # appears in the logs, because that will not be
+    # the correct value.
+    print(salt)

--- a/app/commands.py
+++ b/app/commands.py
@@ -1058,11 +1058,8 @@ def add_test_users_to_db(generate, state, admin):
 # generate a new salt value
 @notify_command(name="generate-salt")
 def generate_salt():
+    if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
+        current_app.logger.error("Can only be run in development")
+        return
     salt = secrets.token_hex(16)
-    # We want to print here.  This value is
-    # generated locally for the developer doing
-    # the salt rotation task, so we don't care if
-    # the task is somehow run on production tier and
-    # appears in the logs, because that will not be
-    # the correct value.
     print(salt)

--- a/app/commands.py
+++ b/app/commands.py
@@ -1054,6 +1054,7 @@ def add_test_users_to_db(generate, state, admin):
         )
         print(f"{num} {user.email_address} created")
 
+
 # generate a new salt value
 @notify_command(name="generate-salt")
 def generate_salt():


### PR DESCRIPTION
## Description

We found that GitHub does not easily support automatic secret rotation so we are going to do it manually for now.  Create a task that will generate a salt, then the developer of the month will follow the steps in the Google calendar task to complete the rotation.

## Security Considerations

N/A