### PR TITLE
further work on phone number validation

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -96,7 +96,6 @@ def cleanup_old_s3_objects():
     time_limit = aware_utcnow() - datetime.timedelta(days=14)
     try:
         response = s3_client.list_objects_v2(Bucket=bucket_name)
-        print(f"RESPONSE = {response}")
         while True:
             for obj in response.get("Contents", []):
                 if obj["LastModified"] <= time_limit:

--- a/app/clients/pinpoint/aws_pinpoint.py
+++ b/app/clients/pinpoint/aws_pinpoint.py
@@ -38,7 +38,9 @@ class AwsPinpointClient(Client):
             # but remove this when that changes
             current_app.logger.info(hilite(response))
         except ClientError:
-            current_app.logger.exception("Could not validate with pinpoint")
+            current_app.logger.exception(
+                "#validate-phone-number Could not validate with pinpoint"
+            )
 
         # TODO This is the structure of the response.  When the phone validation
         # capability we want to offer is better defined (it may just be a question

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -100,8 +100,15 @@ def send_sms_to_provider(notification):
 
                 # TODO This is temporary to test the capability of validating phone numbers
                 # The future home of the validation is TBD
-                if recipient in current_app.config["SIMULATED_SMS_NUMBERS"]:
+                if "+" not in recipient:
+                    recipient_lookup = f"+{recipient}"
+                else:
+                    recipient_lookup = recipient
+                if recipient_lookup in current_app.config["SIMULATED_SMS_NUMBERS"]:
+                    current_app.logger.info(hilite("#validate-phone-number fired"))
                     aws_pinpoint_client.validate_phone_number("01", recipient)
+                else:
+                    current_app.logger.info(hilite("#validate-phone-number not fired"))
 
                 sender_numbers = get_sender_numbers(notification)
                 if notification.reply_to_text not in sender_numbers:


### PR DESCRIPTION
## Description

1. checking if the phone number was in SIMULATED_SMS_NUMBERS failed, because recipient is not stored with a + sign, but SIMULATED_SMS_NUMBERS has plus signs. Fix that.
2. add more debug statements so we know more easily if it worked or not.
3. Remove an unrelated debug statement in s3.py that got checked in somehow.  It is harmless in terms of PII but leads to huge amounts of logging.

Currently this can only be tested on staging, as only staging (theoretically) has pinpoint permissions.  Testing on local will give an 'access denied'.

## Security Considerations

N/A