### PR TITLE
fix load test

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,4 +1,5 @@
 import json
+import os
 from contextlib import suppress
 from urllib import parse
 
@@ -104,7 +105,9 @@ def send_sms_to_provider(notification):
                     recipient_lookup = f"+{recipient}"
                 else:
                     recipient_lookup = recipient
-                if recipient_lookup in current_app.config["SIMULATED_SMS_NUMBERS"]:
+                if recipient_lookup in current_app.config[
+                    "SIMULATED_SMS_NUMBERS"
+                ] and os.getenv("NOTIFY_ENVIRONMENT") in ["development", "test"]:
                     current_app.logger.info(hilite("#validate-phone-number fired"))
                     aws_pinpoint_client.validate_phone_number("01", recipient)
                 else:


### PR DESCRIPTION
## Description

We are doing experimental work to validate phone numbers with pinpoint, and right now that validation is limited to AWS simulated numbers only.  Unfortunately, we are also using the AWS simulated numbers for the load test, so load test on staging is broken due to the problems with pinpoint phone validation.

Add a check to make sure we are on the development or test tiers before doing phone number validation.


## Security Considerations

N/A