### PR TITLE
improve report performance

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -209,7 +209,7 @@
         "filename": "tests/app/aws/test_s3.py",
         "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 28,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-10T18:12:39Z"
+  "generated_at": "2024-09-26T14:17:05Z"
 }

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -196,8 +196,11 @@ def get_s3_files():
     current_app.logger.info(
         f"job_cache length before regen: {len(job_cache)} #notify-admin-1200"
     )
-    with ThreadPoolExecutor() as executor:
-        executor.map(lambda key: read_s3_file(bucket_name, key, s3res), object_keys)
+    try:
+        with ThreadPoolExecutor() as executor:
+            executor.map(lambda key: read_s3_file(bucket_name, key, s3res), object_keys)
+    except Exception:
+        current_app.logger.exception("Connection pool issue")
 
     current_app.logger.info(
         f"job_cache length after regen: {len(job_cache)} #notify-admin-1200"

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -164,20 +164,13 @@ def read_s3_file(bucket_name, object_key, s3res):
                 .read()
                 .decode("utf-8")
             )
-            # TODO we probably don't need this phone number check anymore.
-            # Originally, there were csv uploads that were not valid
-            # for messaging sending.  They may have been experimental, or
-            # they may have not been caught by validation.  When we're sure
-            # all csv files have a phone number column, we can remove the if.
-            # We are essentially just making sure this object looks like a job.
-            if "phone number" in object.lower():
-                set_job_cache(job_cache, job_id, object)
-                set_job_cache(job_cache, f"{job_id}_phones", extract_phones(object))
-                set_job_cache(
-                    job_cache,
-                    f"{job_id}_personalisation",
-                    extract_personalisation(object),
-                )
+            set_job_cache(job_cache, job_id, object)
+            set_job_cache(job_cache, f"{job_id}_phones", extract_phones(object))
+            set_job_cache(
+                job_cache,
+                f"{job_id}_personalisation",
+                extract_personalisation(object),
+            )
 
     except LookupError:
         # perhaps our key is not formatted as we expected.  If so skip it.

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -164,6 +164,12 @@ def read_s3_file(bucket_name, object_key, s3res):
                 .read()
                 .decode("utf-8")
             )
+            # TODO we probably don't need this phone number check anymore.
+            # Originally, there were csv uploads that were not valid
+            # for messaging sending.  They may have been experimental, or
+            # they may have not been caught by validation.  When we're sure
+            # all csv files have a phone number column, we can remove the if.
+            # We are essentially just making sure this object looks like a job.
             if "phone number" in object.lower():
                 set_job_cache(job_cache, job_id, object)
                 set_job_cache(job_cache, f"{job_id}_phones", extract_phones(object))

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -13,6 +13,7 @@ AWS_CLIENT_CONFIG = Config(
         "addressing_style": "virtual",
     },
     use_fips_endpoint=True,
+    max_pool_connections=50,
 )
 
 

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -13,7 +13,10 @@ AWS_CLIENT_CONFIG = Config(
         "addressing_style": "virtual",
     },
     use_fips_endpoint=True,
-    max_pool_connections=50,
+    # This is the default but just for doc sake
+    # there may come a time when increasing this helps
+    # with job cache management
+    max_pool_connections=10,
 )
 
 

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -15,7 +15,7 @@ AWS_CLIENT_CONFIG = Config(
     use_fips_endpoint=True,
     # This is the default but just for doc sake
     # there may come a time when increasing this helps
-    # with job cache management
+    # with job cache management.
     max_pool_connections=10,
 )
 

--- a/app/config.py
+++ b/app/config.py
@@ -256,7 +256,7 @@ class Config(object):
             },
             "regenerate-job-cache": {
                 "task": "regenerate-job-cache",
-                "schedule": crontab(minute="*/30"),
+                "schedule": crontab(minute="*/3"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "regenerate-job-cache-on-startup": {

--- a/app/config.py
+++ b/app/config.py
@@ -256,7 +256,7 @@ class Config(object):
             },
             "regenerate-job-cache": {
                 "task": "regenerate-job-cache",
-                "schedule": crontab(minute="*/3"),
+                "schedule": crontab(minute="*/30"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "regenerate-job-cache-on-startup": {

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -39,6 +39,12 @@ def init_app(app):
     for logger_instance, handler in product(warning_loggers, handlers):
         logger_instance.addHandler(handler)
         logger_instance.setLevel(logging.WARNING)
+
+    # Suppress specific loggers to prevent leaking sensitive info
+    logging.getLogger("boto3").setLevel(logging.ERROR)
+    logging.getLogger("botocore").setLevel(logging.ERROR)
+    logging.getLogger("urllib3").setLevel(logging.ERROR)
+
     app.logger.info("Logging configured")
 
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -8,6 +8,7 @@ from app.aws.s3 import (
     cleanup_old_s3_objects,
     file_exists,
     get_job_from_s3,
+    get_job_id_from_s3_object_key,
     get_personalisation_from_s3,
     get_phone_number_from_s3,
     get_s3_file,
@@ -100,6 +101,21 @@ def test_get_phone_number_from_s3(
     get_job_mock.return_value = job
     phone_number = get_phone_number_from_s3("service_id", job_id, job_row_number)
     assert phone_number == expected_phone_number
+
+
+@pytest.mark.parametrize(
+    "key, expected_job_id",
+    [
+        ("service-blahblahblah-notify/abcde.csv", "abcde"),
+        (
+            "service-x-notify/4c99f361-4ed7-49b1-bd6f-02fe0c807c53.csv",
+            "4c99f361-4ed7-49b1-bd6f-02fe0c807c53",
+        ),
+    ],
+)
+def test_get_job_id_from_s3_object_key(key, expected_job_id):
+    actual_job_id = get_job_id_from_s3_object_key(key)
+    assert actual_job_id == expected_job_id
 
 
 def mock_s3_get_object_slowdown(*args, **kwargs):


### PR DESCRIPTION
## Description

Report performance has been a nagging issue ever since phone numbers got moved out of the db.  In anticipation of future scaling needs, two improvements are being made here:

1.  We're going to use the ThreadPoolExecutor to do download content from S3 files concurrently.  This will speed up the cache regeneration task and take some load off the backend.

2.  When we are grabbing content from S3 we are going to proactively pre-process it and put the phone numbers and personalization into the cache in the form of lists.  This will improve processing speed during report generation because we won't have to go row by row and parse the whole job for each phone number and each personalization.

Note: If we exhaust the connection pool, boto3 will start logging warnings to tell us that, and it will leak the bucket name.  So we are suppressing warnings from boto3, botocore, and urllib3.

Note: I tried increasing max pool connections from 10 to 50, but did not see an improvement in performance.  On my machine we are currently able to pull down the contents of 1007 one-off jobs and load them into the cache in about 6.5 seconds.  This is way better than previously when the time was in minutes.

## Security Considerations

N/A