### PR TITLE
optimize S3 partitioning

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,7 +63,7 @@ jobs:
         NOTIFY_E2E_TEST_PASSWORD: ${{ secrets.NOTIFY_E2E_TEST_PASSWORD }}
     - name: Check coverage threshold
       # TODO get this back up to 95
-      run: poetry run coverage report --fail-under=95
+      run: poetry run coverage report -m --fail-under=95
 
   validate-new-relic-config:
     runs-on: ubuntu-latest

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -278,7 +278,7 @@ def get_job_from_s3(service_id, job_id):
                 "SlowDown",
             ]:
                 current_app.logger.exception(
-                    f"Retrying job fetch  retry_count={retries}",
+                    f"Retrying job fetch service_id {service_id} job_id {job_id} retry_count={retries}",
                 )
                 retries += 1
                 sleep_time = backoff_factor * (2**retries)  # Exponential backoff

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -12,6 +12,7 @@ from app.clients import AWS_CLIENT_CONFIG
 from notifications_utils import aware_utcnow
 
 FILE_LOCATION_STRUCTURE = "service-{}-notify/{}.csv"
+NEW_FILE_LOCATION_STRUCTURE = "{}-service-notify/{}.csv"
 
 # Temporarily extend cache to 7 days
 ttl = 60 * 60 * 24 * 7
@@ -213,6 +214,21 @@ def file_exists(file_location):
 def get_job_location(service_id, job_id):
     return (
         current_app.config["CSV_UPLOAD_BUCKET"]["bucket"],
+        NEW_FILE_LOCATION_STRUCTURE.format(service_id, job_id),
+        current_app.config["CSV_UPLOAD_BUCKET"]["access_key_id"],
+        current_app.config["CSV_UPLOAD_BUCKET"]["secret_access_key"],
+        current_app.config["CSV_UPLOAD_BUCKET"]["region"],
+    )
+
+
+def get_old_job_location(service_id, job_id):
+    """
+    This is deprecated. We are transitioning to NEW_FILE_LOCATION_STRUCTURE,
+    but it will take a few days where we have to support both formats.
+    Remove this when everything works with the NEW_FILE_LOCATION_STRUCTURE.
+    """
+    return (
+        current_app.config["CSV_UPLOAD_BUCKET"]["bucket"],
         FILE_LOCATION_STRUCTURE.format(service_id, job_id),
         current_app.config["CSV_UPLOAD_BUCKET"]["access_key_id"],
         current_app.config["CSV_UPLOAD_BUCKET"]["secret_access_key"],
@@ -239,9 +255,11 @@ def get_job_from_s3(service_id, job_id):
     max_retries = 4
     backoff_factor = 0.2
 
-    if not file_exists(FILE_LOCATION_STRUCTURE.format(service_id, job_id)):
+    if not file_exists(
+        FILE_LOCATION_STRUCTURE.format(service_id, job_id)
+    ) and not file_exists(NEW_FILE_LOCATION_STRUCTURE.format(service_id, job_id)):
         current_app.logger.error(
-            f"This file does not exist {FILE_LOCATION_STRUCTURE.format(service_id, job_id)}"
+            f"This file with service_id {service_id} and job_id {job_id} does not exist"
         )
         return None
 
@@ -249,6 +267,9 @@ def get_job_from_s3(service_id, job_id):
 
         try:
             obj = get_s3_object(*get_job_location(service_id, job_id))
+            # TODO remove this when we have fully transitioned to the NEW_FILE_LOCATION_STRUCTURE
+            if obj is None:
+                obj = get_s3_object(*get_old_job_location(service_id, job_id))
             return obj.get()["Body"].read().decode("utf-8")
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] in [
@@ -257,7 +278,7 @@ def get_job_from_s3(service_id, job_id):
                 "SlowDown",
             ]:
                 current_app.logger.exception(
-                    f"Retrying job fetch {FILE_LOCATION_STRUCTURE.format(service_id, job_id)} retry_count={retries}",
+                    f"Retrying job fetch  retry_count={retries}",
                 )
                 retries += 1
                 sleep_time = backoff_factor * (2**retries)  # Exponential backoff
@@ -266,18 +287,18 @@ def get_job_from_s3(service_id, job_id):
             else:
                 # Typically this is "NoSuchKey"
                 current_app.logger.exception(
-                    f"Failed to get job {FILE_LOCATION_STRUCTURE.format(service_id, job_id)}",
+                    f"Failed to get job with service_id {service_id} job_id {job_id}",
                 )
                 return None
 
         except Exception:
             current_app.logger.exception(
-                f"Failed to get job {FILE_LOCATION_STRUCTURE.format(service_id, job_id)} retry_count={retries}",
+                f"Failed to get job with service_id {service_id} job_id {job_id}retry_count={retries}",
             )
             return None
 
     current_app.logger.error(
-        f"Never retrieved job {FILE_LOCATION_STRUCTURE.format(service_id, job_id)}",
+        f"Never retrieved job with service_id {service_id} job_id {job_id}",
     )
     return None
 
@@ -358,7 +379,7 @@ def get_phone_number_from_s3(service_id, job_id, job_row_number):
 
     if job is None:
         current_app.logger.error(
-            f"Couldnt find phone for job {FILE_LOCATION_STRUCTURE.format(service_id, job_id)} because job is missing"
+            f"Couldnt find phone for job with service_id {service_id} job_id {job_id} because job is missing"
         )
         return "Unavailable"
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -931,7 +931,7 @@ where possible to enable better maintainability.
 # generate n number of test orgs into the dev DB
 @notify_command(name="add-test-organizations-to-db")
 @click.option("-g", "--generate", required=True, prompt=True, default=1)
-def add_test_organizations_to_db(generate):
+def add_test_organizations_to_db(generate):  # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return
@@ -993,7 +993,7 @@ def add_test_organizations_to_db(generate):
 # generate n number of test services into the dev DB
 @notify_command(name="add-test-services-to-db")
 @click.option("-g", "--generate", required=True, prompt=True, default=1)
-def add_test_services_to_db(generate):
+def add_test_services_to_db(generate):  # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return
@@ -1007,7 +1007,7 @@ def add_test_services_to_db(generate):
 # generate n number of test jobs into the dev DB
 @notify_command(name="add-test-jobs-to-db")
 @click.option("-g", "--generate", required=True, prompt=True, default=1)
-def add_test_jobs_to_db(generate):
+def add_test_jobs_to_db(generate):  # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return
@@ -1022,7 +1022,7 @@ def add_test_jobs_to_db(generate):
 # generate n number of notifications into the dev DB
 @notify_command(name="add-test-notifications-to-db")
 @click.option("-g", "--generate", required=True, prompt=True, default=1)
-def add_test_notifications_to_db(generate):
+def add_test_notifications_to_db(generate):  # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return
@@ -1043,7 +1043,7 @@ def add_test_notifications_to_db(generate):
 @click.option("-g", "--generate", required=True, prompt=True, default="1")
 @click.option("-s", "--state", default="active")
 @click.option("-d", "--admin", default=False, type=bool)
-def add_test_users_to_db(generate, state, admin):
+def add_test_users_to_db(generate, state, admin): # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return

--- a/app/commands.py
+++ b/app/commands.py
@@ -1043,7 +1043,7 @@ def add_test_notifications_to_db(generate):  # pragma: no cover
 @click.option("-g", "--generate", required=True, prompt=True, default="1")
 @click.option("-s", "--state", default="active")
 @click.option("-d", "--admin", default=False, type=bool)
-def add_test_users_to_db(generate, state, admin): # pragma: no cover
+def add_test_users_to_db(generate, state, admin):  # pragma: no cover
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -151,7 +151,7 @@ def test_get_job_from_s3_exponential_backoff_on_throttling(mocker):
     mocker.patch("app.aws.s3.file_exists", return_value=True)
     job = get_job_from_s3("service_id", "job_id")
     assert job is None
-    assert mock_get_object.call_count == 4
+    assert mock_get_object.call_count == 8
 
 
 def test_get_job_from_s3_exponential_backoff_file_not_found(mocker):


### PR DESCRIPTION
## Description

We inherited a way of naming s3 objects which might have been fine in its original context, but is not optimal for AWS.  For S3, we should not be prefixing all of our s3 objects with "service-uuid" because it pushes everything onto one partition, which will affect search speeds as we scale.  Change the name format to "uuid-service"

Note:  This PR is has a matching PR on the admin side.  They should be checked in at the same time.  

## Security Considerations

N/A