### PR TITLE
Adjust LOGIN_DOT_GOV_REGISTRATION_URL env var in staging deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
         cf_org: gsa-tts-benefits-studio
         cf_space: notify-staging
-        cf_command: "push -f manifest.yml --vars-file deploy-config/staging.yml --var var-name=${{ secrets.DANGEROUS_SALT }} --var var-name=${{ secrets.SECRET_KEY }} --var var-name=${{ secrets.ADMIN_CLIENT_SECRET }} --var var-name=${{ secrets.NEW_RELIC_LICENSE_KEY }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_EMAIL }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_PASSWORD }} --var var-name=${{ LOGIN_DOT_GOV_REGISTRATION_URL }} --strategy rolling"
+        cf_command: "push -f manifest.yml --vars-file deploy-config/staging.yml --var var-name=${{ secrets.DANGEROUS_SALT }} --var var-name=${{ secrets.SECRET_KEY }} --var var-name=${{ secrets.ADMIN_CLIENT_SECRET }} --var var-name=${{ secrets.NEW_RELIC_LICENSE_KEY }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_EMAIL }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_PASSWORD }} --var LOGIN_DOT_GOV_REGISTRATION_URL=https://secure.login.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:notify-gov&nonce=NONCE&prompt=select_account&redirect_uri=https://notify-staging.app.cloud.gov/set-up-your-profile&response_type=code&scope=openid+email&state=STATE --strategy rolling"
 
     - name: Check for changes to templates.json
       id: changed-templates


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset will hopefully fix the reference to the `LOGIN_DOT_GOV_REGISTRATION_URL` env var in the new `cf_command`.

## Security Considerations

* The value in question is not a secret, unlike the others.
