### PR TITLE
One more attempt at fixing the Login.gov registration URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
         cf_org: gsa-tts-benefits-studio
         cf_space: notify-staging
-        cf_command: "push -f manifest.yml --vars-file deploy-config/staging.yml --var var-name=${{ secrets.DANGEROUS_SALT }} --var var-name=${{ secrets.SECRET_KEY }} --var var-name=${{ secrets.ADMIN_CLIENT_SECRET }} --var var-name=${{ secrets.NEW_RELIC_LICENSE_KEY }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_EMAIL }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_PASSWORD }} --var LOGIN_DOT_GOV_REGISTRATION_URL=$LOGIN_DOT_GOV_REGISTRATION_URL --strategy rolling"
+        cf_command: "push -f manifest.yml --vars-file deploy-config/staging.yml --var var-name=${{ secrets.DANGEROUS_SALT }} --var var-name=${{ secrets.SECRET_KEY }} --var var-name=${{ secrets.ADMIN_CLIENT_SECRET }} --var var-name=${{ secrets.NEW_RELIC_LICENSE_KEY }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_EMAIL }} --var var-name=${{ secrets.NOTIFY_E2E_TEST_PASSWORD }} --var var-name=${{ env.LOGIN_DOT_GOV_REGISTRATION_URL }} --strategy rolling"
 
     - name: Check for changes to templates.json
       id: changed-templates


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset attempts another fix by referencing the environment variable in a different fashion, according to the GitHub docs:

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#example-usage-of-the-env-context

## Security Considerations

* We're being mindful of the difference between GitHub secrets and public code.
