### PR TITLE
US-NOTIFY-COMPLY 50: Verify Nonce For Invite

### DIFF
--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -32,19 +32,13 @@ service_invite = Blueprint("service_invite", __name__)
 register_errors(service_invite)
 
 
-def _create_service_invite(invited_user, invite_link_host):
+def _create_service_invite(invited_user, nonce):
 
     template_id = current_app.config["INVITATION_EMAIL_TEMPLATE_ID"]
 
     template = dao_get_template_by_id(template_id)
 
     service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
-
-    token = generate_token(
-        str(invited_user.email_address),
-        current_app.config["SECRET_KEY"],
-        current_app.config["DANGEROUS_SALT"],
-    )
 
     # The raw permissions are in the form "a,b,c,d"
     # but need to be in the form ["a", "b", "c", "d"]
@@ -59,7 +53,8 @@ def _create_service_invite(invited_user, invite_link_host):
     data["invited_user_email"] = invited_user.email_address
 
     url = os.environ["LOGIN_DOT_GOV_REGISTRATION_URL"]
-    url = url.replace("NONCE", token)
+
+    url = url.replace("NONCE", nonce)  # handed from data sent from admin.
 
     user_data_url_safe = get_user_data_url_safe(data)
 
@@ -94,10 +89,16 @@ def _create_service_invite(invited_user, invite_link_host):
 @service_invite.route("/service/<service_id>/invite", methods=["POST"])
 def create_invited_user(service_id):
     request_json = request.get_json()
+    try:
+        nonce = request_json.pop("nonce")
+    except KeyError:
+        current_app.logger.exception("nonce not found in submitted data.")
+        raise
+
     invited_user = invited_user_schema.load(request_json)
     save_invited_user(invited_user)
 
-    _create_service_invite(invited_user, request_json.get("invite_link_host"))
+    _create_service_invite(invited_user, nonce)
 
     return jsonify(data=invited_user_schema.dump(invited_user)), 201
 

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -45,6 +45,7 @@ def test_create_invited_user(
         permissions="send_messages,manage_service,manage_api_keys",
         auth_type=AuthType.EMAIL,
         folder_permissions=["folder_1", "folder_2", "folder_3"],
+        nonce="FakeNonce",
         **extra_args,
     )
 
@@ -108,6 +109,7 @@ def test_create_invited_user_without_auth_type(
         "from_user": str(invite_from.id),
         "permissions": "send_messages,manage_service,manage_api_keys",
         "folder_permissions": [],
+        "nonce": "FakeNonce",
     }
 
     json_resp = admin_request.post(
@@ -131,6 +133,7 @@ def test_create_invited_user_invalid_email(client, sample_service, mocker, fake_
         "from_user": str(invite_from.id),
         "permissions": "send_messages,manage_service,manage_api_keys",
         "folder_permissions": [fake_uuid, fake_uuid],
+        "nonce": "FakeNonce",
     }
 
     data = json.dumps(data)


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

Makes nonce opertions for login.gov work for invites as well as the logins now. (api side)

## Issue

https://github.com/GSA/us-notify-compliance/issues/50

## Security Considerations

This improves the security for logins through login.gov.


## NOTE

Do not merge until https://github.com/GSA/notifications-admin/pull/2024 is also ready.