### PR TITLE
Fix reference to prod space

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -106,5 +106,5 @@ jobs:
           CF_PASSWORD: ${{ secrets.CLOUDGOV_PASSWORD }}
       with:
         cf_org: gsa-tts-benefits-studio
-        cf_space: notify-prod
-        app: notify-api-prod
+        cf_space: notify-production
+        app: notify-api-production


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset fixes the name of the prod space (notify-production).

## Security Considerations

* We need to make sure we can update and deploy the egress proxy.