### PR TITLE
upgrade test queries to sqlalchemy 2.0

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -349,7 +349,7 @@
         "filename": "tests/app/user/test_rest.py",
         "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
         "is_verified": false,
-        "line_number": 822,
+        "line_number": 826,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-31T18:32:23Z"
+  "generated_at": "2024-10-31T18:48:03Z"
 }

--- a/.ds.baseline
+++ b/.ds.baseline
@@ -267,7 +267,7 @@
         "filename": "tests/app/db.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 90,
         "is_secret": false
       }
     ],
@@ -305,7 +305,7 @@
         "filename": "tests/app/service/test_rest.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1284,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-28T20:26:27Z"
+  "generated_at": "2024-10-30T18:15:03Z"
 }

--- a/.ds.baseline
+++ b/.ds.baseline
@@ -341,7 +341,7 @@
         "filename": "tests/app/user/test_rest.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 108,
         "is_secret": false
       },
       {
@@ -349,7 +349,7 @@
         "filename": "tests/app/user/test_rest.py",
         "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
         "is_verified": false,
-        "line_number": 810,
+        "line_number": 822,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-30T18:15:03Z"
+  "generated_at": "2024-10-31T18:32:23Z"
 }

--- a/.ds.baseline
+++ b/.ds.baseline
@@ -277,7 +277,7 @@
         "filename": "tests/app/notifications/test_receive_notification.py",
         "hashed_secret": "913a73b565c8e2c8ed94497580f619397709b8b6",
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 26,
         "is_secret": false
       },
       {
@@ -285,7 +285,7 @@
         "filename": "tests/app/notifications/test_receive_notification.py",
         "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 56,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-31T18:48:03Z"
+  "generated_at": "2024-10-31T21:25:32Z"
 }

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 
 from flask import current_app
-from sqlalchemy import between, select
+from sqlalchemy import between
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, notify_celery, zendesk_client
+from app import notify_celery, zendesk_client
 from app.celery.tasks import (
     get_recipient_csv_and_template_and_sender_id,
     process_incomplete_jobs,
@@ -105,23 +105,21 @@ def check_job_status():
     thirty_minutes_ago = utc_now() - timedelta(minutes=30)
     thirty_five_minutes_ago = utc_now() - timedelta(minutes=35)
 
-    incomplete_in_progress_jobs = select(Job).where(
+    incomplete_in_progress_jobs = Job.query.filter(
         Job.job_status == JobStatus.IN_PROGRESS,
         between(Job.processing_started, thirty_five_minutes_ago, thirty_minutes_ago),
     )
-    # incomplete_in_progress_jobs = db.session.execute(stmt).scalars().all()
-
-    incomplete_pending_jobs = select(Job).where(
+    incomplete_pending_jobs = Job.query.filter(
         Job.job_status == JobStatus.PENDING,
         Job.scheduled_for.isnot(None),
         between(Job.scheduled_for, thirty_five_minutes_ago, thirty_minutes_ago),
     )
-    # incomplete_pending_jobs = db.session.execute(stmt).scalars().all()
 
-    stmt = incomplete_in_progress_jobs.union(incomplete_pending_jobs).order_by(
-        Job.processing_started, Job.scheduled_for
+    jobs_not_complete_after_30_minutes = (
+        incomplete_in_progress_jobs.union(incomplete_pending_jobs)
+        .order_by(Job.processing_started, Job.scheduled_for)
+        .all()
     )
-    jobs_not_complete_after_30_minutes = db.session.execute(stmt).scalars().all()
 
     # temporarily mark them as ERROR so that they don't get picked up by future check_job_status tasks
     # if they haven't been re-processed in time.

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 
 from flask import current_app
-from sqlalchemy import between
+from sqlalchemy import between, select
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import notify_celery, zendesk_client
+from app import db, notify_celery, zendesk_client
 from app.celery.tasks import (
     get_recipient_csv_and_template_and_sender_id,
     process_incomplete_jobs,
@@ -105,15 +105,18 @@ def check_job_status():
     thirty_minutes_ago = utc_now() - timedelta(minutes=30)
     thirty_five_minutes_ago = utc_now() - timedelta(minutes=35)
 
-    incomplete_in_progress_jobs = Job.query.filter(
+    stmt = select(Job).where(
         Job.job_status == JobStatus.IN_PROGRESS,
         between(Job.processing_started, thirty_five_minutes_ago, thirty_minutes_ago),
     )
-    incomplete_pending_jobs = Job.query.filter(
+    incomplete_in_progress_jobs = db.session.execute(stmt).scalars().all()
+
+    stmt = select(Job).where(
         Job.job_status == JobStatus.PENDING,
         Job.scheduled_for.isnot(None),
         between(Job.scheduled_for, thirty_five_minutes_ago, thirty_minutes_ago),
     )
+    incomplete_pending_jobs = db.session.execute(stmt).scalars().all()
 
     jobs_not_complete_after_30_minutes = (
         incomplete_in_progress_jobs.union(incomplete_pending_jobs)

--- a/app/commands.py
+++ b/app/commands.py
@@ -646,8 +646,9 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
     This is useful to ensure all services start the new year with the correct annual billing.
     """
     if missing_services_only:
-        active_services = (
-            Service.query.filter(Service.active)
+        stmt = (
+            select(Service)
+            .where(Service.active)
             .outerjoin(
                 AnnualBilling,
                 and_(
@@ -656,10 +657,11 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
                 ),
             )
             .filter(AnnualBilling.id == None)  # noqa
-            .all()
         )
+        active_services = db.session.execute(stmt).scalars().all()
     else:
-        active_services = Service.query.filter(Service.active).all()
+        stmt = select(Service).where(Service.active)
+        active_services = db.session.execute(stmt).scalars().all()
     previous_year = year - 1
     services_with_zero_free_allowance = (
         db.session.query(AnnualBilling.service_id)

--- a/app/commands.py
+++ b/app/commands.py
@@ -12,7 +12,7 @@ from click_datetime import Datetime as click_dt
 from faker import Faker
 from flask import current_app, json
 from notifications_python_client.authentication import create_jwt_token
-from sqlalchemy import and_, text
+from sqlalchemy import and_, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -123,8 +123,8 @@ def purge_functional_test_data(user_email_prefix):
     if getenv("NOTIFY_ENVIRONMENT", "") not in ["development", "test"]:
         current_app.logger.error("Can only be run in development")
         return
-
-    users = User.query.filter(User.email_address.like(f"{user_email_prefix}%")).all()
+    stmt = select(User).where(User.email_address.like(f"{user_email_prefix}%"))
+    users = db.session.execute(stmt).scalars().all()
     for usr in users:
         # Make sure the full email includes a uuid in it
         # Just in case someone decides to use a similar email address.
@@ -338,9 +338,10 @@ def populate_organizations_from_file(file_name):
             email_branding = None
             email_branding_column = columns[5].strip()
             if len(email_branding_column) > 0:
-                email_branding = EmailBranding.query.filter(
+                stmt = select(EmailBranding).where(
                     EmailBranding.name == email_branding_column
-                ).one()
+                )
+                email_branding = db.session.execute(stmt).scalars().one()
             data = {
                 "name": columns[0],
                 "active": True,
@@ -406,10 +407,14 @@ def populate_organization_agreement_details_from_file(file_name):
 
 @notify_command(name="associate-services-to-organizations")
 def associate_services_to_organizations():
-    services = Service.get_history_model().query.filter_by(version=1).all()
+    stmt = select(Service.get_history_model()).where(
+        Service.get_history_model().version == 1
+    )
+    services = db.session.execute(stmt).scalars().all()
 
     for s in services:
-        created_by_user = User.query.filter_by(id=s.created_by_id).first()
+        stmt = select(User).where(User.id == s.created_by_id)
+        created_by_user = db.session.execute(stmt).scalars().first()
         organization = dao_get_organization_by_email_address(
             created_by_user.email_address
         )
@@ -467,15 +472,16 @@ def populate_go_live(file_name):
 
 @notify_command(name="fix-billable-units")
 def fix_billable_units():
-    query = Notification.query.filter(
+    stmt = select(Notification).where(
         Notification.notification_type == NotificationType.SMS,
         Notification.status != NotificationStatus.CREATED,
         Notification.sent_at == None,  # noqa
         Notification.billable_units == 0,
         Notification.key_type != KeyType.TEST,
     )
+    all = db.session.execute(stmt).scalars().all()
 
-    for notification in query.all():
+    for notification in all:
         template_model = dao_get_template_by_id(
             notification.template_id, notification.template_version
         )
@@ -490,9 +496,12 @@ def fix_billable_units():
             f"Updating notification: {notification.id} with {template.fragment_count} billable_units"
         )
 
-        Notification.query.filter(Notification.id == notification.id).update(
-            {"billable_units": template.fragment_count}
+        stmt = (
+            update(Notification)
+            .where(Notification.id == notification.id)
+            .values({"billable_units": template.fragment_count})
         )
+        db.session.execute(stmt)
     db.session.commit()
     current_app.logger.info("End fix_billable_units")
 
@@ -637,8 +646,8 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
     This is useful to ensure all services start the new year with the correct annual billing.
     """
     if missing_services_only:
-        active_services = (
-            Service.query.filter(Service.active)
+        stmt = (
+            select(Service)
             .outerjoin(
                 AnnualBilling,
                 and_(
@@ -646,20 +655,18 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
                     AnnualBilling.financial_year_start == year,
                 ),
             )
-            .filter(AnnualBilling.id == None)  # noqa
-            .all()
+            .where(Service.active, AnnualBilling.id == None)  # noqa
         )
+        active_services = db.session.execute(stmt).scalars().all()
     else:
-        active_services = Service.query.filter(Service.active).all()
+        stmt = select(Service).where(Service.active)
+        active_services = db.session.execute(stmt).scalars().all()
     previous_year = year - 1
-    services_with_zero_free_allowance = (
-        db.session.query(AnnualBilling.service_id)
-        .filter(
-            AnnualBilling.financial_year_start == previous_year,
-            AnnualBilling.free_sms_fragment_limit == 0,
-        )
-        .all()
+    stmt = select(AnnualBilling.id).where(
+        AnnualBilling.financial_year_start == previous_year,
+        AnnualBilling.free_sms_fragment_limit == 0,
     )
+    services_with_zero_free_allowance = db.session.execute(stmt).scalars().all()
 
     for service in active_services:
         # If a service has free_sms_fragment_limit for the previous year
@@ -750,7 +757,8 @@ def create_user_jwt(token):
 
 
 def _update_template(id, name, template_type, content, subject):
-    template = Template.query.filter_by(id=id).first()
+    stmt = select(Template).where(Template.id == id)
+    template = db.session.execute(stmt).scalars().first()
     if not template:
         template = Template(id=id)
         template.service_id = "d6aa2c68-a2d9-4437-ab19-3ae8eb202553"
@@ -761,7 +769,8 @@ def _update_template(id, name, template_type, content, subject):
     template.content = "\n".join(content)
     template.subject = subject
 
-    history = TemplateHistory.query.filter_by(id=id).first()
+    stmt = select(TemplateHistory).where(TemplateHistory.id == id)
+    history = db.session.execute(stmt).scalars().first()
     if not history:
         history = TemplateHistory(id=id)
         history.service_id = "d6aa2c68-a2d9-4437-ab19-3ae8eb202553"

--- a/app/commands.py
+++ b/app/commands.py
@@ -655,7 +655,8 @@ def populate_annual_billing_with_defaults(year, missing_services_only):
                     AnnualBilling.financial_year_start == year,
                 ),
             )
-            .where(Service.active, AnnualBilling.id == None)  # noqa
+            .where(Service.active)
+            .where(AnnualBilling.id == None)  # noqa
         )
         active_services = db.session.execute(stmt).scalars().all()
     else:

--- a/app/dao/invited_user_dao.py
+++ b/app/dao/invited_user_dao.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+from sqlalchemy import select
+
 from app import db
 from app.enums import InvitedUserStatus
 from app.models import InvitedUser
@@ -12,30 +14,37 @@ def save_invited_user(invited_user):
 
 
 def get_invited_user_by_service_and_id(service_id, invited_user_id):
-    return InvitedUser.query.filter(
+
+    stmt = select(InvitedUser).where(
         InvitedUser.service_id == service_id,
         InvitedUser.id == invited_user_id,
-    ).one()
+    )
+    return db.session.execute(stmt).scalars().one()
 
 
 def get_expired_invite_by_service_and_id(service_id, invited_user_id):
-    return InvitedUser.query.filter(
+    stmt = select(InvitedUser).where(
         InvitedUser.service_id == service_id,
         InvitedUser.id == invited_user_id,
         InvitedUser.status == InvitedUserStatus.EXPIRED,
-    ).one()
+    )
+    return db.session.execute(stmt).scalars().all()
 
 
 def get_invited_user_by_id(invited_user_id):
-    return InvitedUser.query.filter(InvitedUser.id == invited_user_id).one()
+    stmt = select(InvitedUser).where(InvitedUser.id == invited_user_id)
+    return db.session.execute(stmt).scalars().one()
 
 
 def get_expired_invited_users_for_service(service_id):
-    return InvitedUser.query.filter(InvitedUser.service_id == service_id).all()
+    # TODO why does this return all invited users?
+    stmt = select(InvitedUser).where(InvitedUser.service_id == service_id)
+    return db.session.execute(stmt).scalars().all()
 
 
 def get_invited_users_for_service(service_id):
-    return InvitedUser.query.filter(InvitedUser.service_id == service_id).all()
+    stmt = select(InvitedUser).where(InvitedUser.service_id == service_id)
+    return db.session.execute(stmt).scalars().all()
 
 
 def expire_invitations_created_more_than_two_days_ago():

--- a/app/dao/invited_user_dao.py
+++ b/app/dao/invited_user_dao.py
@@ -28,7 +28,7 @@ def get_expired_invite_by_service_and_id(service_id, invited_user_id):
         InvitedUser.id == invited_user_id,
         InvitedUser.status == InvitedUserStatus.EXPIRED,
     )
-    return db.session.execute(stmt).scalars().all()
+    return db.session.execute(stmt).scalars().one()
 
 
 def get_invited_user_by_id(invited_user_id):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -192,6 +192,7 @@ def get_notifications_for_job(
 ):
     if page_size is None:
         page_size = current_app.config["PAGE_SIZE"]
+
     query = Notification.query.filter_by(service_id=service_id, job_id=job_id)
     query = _filter_query(query, filter_dict)
     return query.order_by(asc(Notification.job_row_number)).paginate(

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from flask import current_app
-from sqlalchemy import desc, func
+from sqlalchemy import desc, func, select
 
 from app import db
 from app.dao.dao_utils import autocommit
@@ -11,11 +11,12 @@ from app.utils import utc_now
 
 
 def get_provider_details_by_id(provider_details_id):
-    return ProviderDetails.query.get(provider_details_id)
+    return db.session.get(ProviderDetails, provider_details_id)
 
 
 def get_provider_details_by_identifier(identifier):
-    return ProviderDetails.query.filter_by(identifier=identifier).one()
+    stmt = select(ProviderDetails).where(identifier=identifier)
+    return db.session.execute(stmt).scalars().one()
 
 
 def get_alternative_sms_provider(identifier):

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -30,9 +30,10 @@ def dao_get_provider_versions(provider_id):
         select(ProviderDetailsHistory)
         .where(ProviderDetailsHistory.id == provider_id)
         .order_by(desc(ProviderDetailsHistory.version))
+        .limit(100)
     )
     # limit results instead of adding pagination
-    return db.session.execute(stmt).limit(100).scalars().all()
+    return db.session.execute(stmt).scalars().all()
 
 
 def _get_sms_providers_for_update(time_threshold):

--- a/app/dao/service_guest_list_dao.py
+++ b/app/dao/service_guest_list_dao.py
@@ -1,11 +1,12 @@
+from sqlalchemy import delete, select
+
 from app import db
 from app.models import ServiceGuestList
 
 
 def dao_fetch_service_guest_list(service_id):
-    return ServiceGuestList.query.filter(
-        ServiceGuestList.service_id == service_id
-    ).all()
+    stmt = select(ServiceGuestList).where(ServiceGuestList.service_id == service_id)
+    return db.session.execute(stmt).scalars().all()
 
 
 def dao_add_and_commit_guest_list_contacts(objs):
@@ -14,6 +15,7 @@ def dao_add_and_commit_guest_list_contacts(objs):
 
 
 def dao_remove_service_guest_list(service_id):
-    return ServiceGuestList.query.filter(
-        ServiceGuestList.service_id == service_id
-    ).delete()
+    stmt = delete(ServiceGuestList).where(ServiceGuestList.service_id == service_id)
+    result = db.session.execute(stmt)
+    db.session.commit()
+    return result.rowcount

--- a/app/dao/service_guest_list_dao.py
+++ b/app/dao/service_guest_list_dao.py
@@ -17,5 +17,4 @@ def dao_add_and_commit_guest_list_contacts(objs):
 def dao_remove_service_guest_list(service_id):
     stmt = delete(ServiceGuestList).where(ServiceGuestList.service_id == service_id)
     result = db.session.execute(stmt)
-    db.session.commit()
     return result.rowcount

--- a/app/dao/webauthn_credential_dao.py
+++ b/app/dao/webauthn_credential_dao.py
@@ -1,13 +1,16 @@
+from sqlalchemy import select
+
 from app import db
 from app.dao.dao_utils import autocommit
 from app.models import WebauthnCredential
 
 
 def dao_get_webauthn_credential_by_user_and_id(user_id, webauthn_credential_id):
-    return WebauthnCredential.query.filter(
+    stmt = select(WebauthnCredential).where(
         WebauthnCredential.user_id == user_id,
         WebauthnCredential.id == webauthn_credential_id,
-    ).one()
+    )
+    return db.session.execute(stmt).scalars().one()
 
 
 @autocommit

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1379,7 +1379,7 @@ def test_process_incomplete_job_email(mocker, sample_email_template):
     create_notification(sample_email_template, job, 0)
     create_notification(sample_email_template, job, 1)
 
-    stmt = select(Notification).where(Notification.job_id == job.id)
+    stmt = select(func.count()).select_from(Notification).where(Notification.job_id == job.id)
     assert db.session.execute(stmt).scalar() == 2
 
     process_incomplete_job(str(job.id))

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1379,7 +1379,11 @@ def test_process_incomplete_job_email(mocker, sample_email_template):
     create_notification(sample_email_template, job, 0)
     create_notification(sample_email_template, job, 1)
 
-    stmt = select(func.count()).select_from(Notification).where(Notification.job_id == job.id)
+    stmt = (
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.job_id == job.id)
+    )
     assert db.session.execute(stmt).scalar() == 2
 
     process_incomplete_job(str(job.id))

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -2,7 +2,9 @@ import uuid
 from datetime import datetime, timedelta
 
 from freezegun import freeze_time
+from sqlalchemy import func, select
 
+from app import db
 from app.dao.notifications_dao import (
     insert_notification_history_delete_notifications,
     move_notifications_to_notification_history,
@@ -172,12 +174,13 @@ def test_move_notifications_just_deletes_test_key_notifications(sample_template)
 
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 2
-    assert (
-        NotificationHistory.query.filter(
-            NotificationHistory.key_type == KeyType.TEST
-        ).count()
-        == 0
+    stmt = (
+        select(func.count())
+        .select_from(NotificationHistory)
+        .where(NotificationHistory.key_type == KeyType.TEST)
     )
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 0
 
 
 @freeze_time("2020-03-20 14:00")

--- a/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_delete_notifications.py
@@ -42,10 +42,15 @@ def test_move_notifications_does_nothing_if_notification_history_row_already_exi
         1,
     )
 
-    assert Notification.query.count() == 0
+    assert _get_notification_count() == 0
     history = NotificationHistory.query.all()
     assert len(history) == 1
     assert history[0].status == NotificationStatus.DELIVERED
+
+
+def _get_notification_count():
+    stmt = select(func.count()).select_from(Notification)
+    return db.session.execute(stmt).scalar() or 0
 
 
 def test_move_notifications_only_moves_notifications_older_than_provided_timestamp(
@@ -172,8 +177,10 @@ def test_move_notifications_just_deletes_test_key_notifications(sample_template)
 
     assert result == 2
 
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 2
+    assert _get_notification_count() == 0
+    stmt = select(func.count()).select_from(NotificationHistory)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 2
     stmt = (
         select(func.count())
         .select_from(NotificationHistory)

--- a/tests/app/dao/test_events_dao.py
+++ b/tests/app/dao/test_events_dao.py
@@ -1,9 +1,14 @@
+from sqlalchemy import func, select
+
+from app import db
 from app.dao.events_dao import dao_create_event
 from app.models import Event
 
 
 def test_create_event(notify_db_session):
-    assert Event.query.count() == 0
+    stmt = select(func.count()).select_from(Event)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 0
     data = {
         "event_type": "sucessful_login",
         "data": {"something": "random", "in_fact": "could be anything"},
@@ -12,6 +17,8 @@ def test_create_event(notify_db_session):
     event = Event(**data)
     dao_create_event(event)
 
-    assert Event.query.count() == 1
+    stmt = select(func.count()).select_from(Event)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 1
     event_from_db = Event.query.first()
     assert event == event_from_db

--- a/tests/app/dao/test_invited_user_dao.py
+++ b/tests/app/dao/test_invited_user_dao.py
@@ -19,8 +19,13 @@ from app.utils import utc_now
 from tests.app.db import create_invited_user
 
 
+def _get_invited_user_count():
+    stmt = select(func.count()).select_from(InvitedUser)
+    return db.session.execute(stmt).scalar() or 0
+
+
 def test_create_invited_user(notify_db_session, sample_service):
-    assert InvitedUser.query.count() == 0
+    assert _get_invited_user_count() == 0
     email_address = "invited_user@service.gov.uk"
     invite_from = sample_service.users[0]
 
@@ -35,7 +40,7 @@ def test_create_invited_user(notify_db_session, sample_service):
     invited_user = InvitedUser(**data)
     save_invited_user(invited_user)
 
-    assert InvitedUser.query.count() == 1
+    assert _get_invited_user_count() == 1
     assert invited_user.email_address == email_address
     assert invited_user.from_user == invite_from
     permissions = invited_user.get_permissions()
@@ -48,7 +53,7 @@ def test_create_invited_user(notify_db_session, sample_service):
 def test_create_invited_user_sets_default_folder_permissions_of_empty_list(
     sample_service,
 ):
-    assert InvitedUser.query.count() == 0
+    assert _get_invited_user_count() == 0
     invite_from = sample_service.users[0]
 
     data = {
@@ -61,7 +66,7 @@ def test_create_invited_user_sets_default_folder_permissions_of_empty_list(
     invited_user = InvitedUser(**data)
     save_invited_user(invited_user)
 
-    assert InvitedUser.query.count() == 1
+    assert _get_invited_user_count() == 1
     assert invited_user.folder_permissions == []
 
 
@@ -109,12 +114,12 @@ def test_get_invited_users_for_service_that_has_no_invites(
 def test_save_invited_user_sets_status_to_cancelled(
     notify_db_session, sample_invited_user
 ):
-    assert InvitedUser.query.count() == 1
+    assert _get_invited_user_count() == 1
     saved = InvitedUser.query.get(sample_invited_user.id)
     assert saved.status == InvitedUserStatus.PENDING
     saved.status = InvitedUserStatus.CANCELLED
     save_invited_user(saved)
-    assert InvitedUser.query.count() == 1
+    assert _get_invited_user_count() == 1
     cancelled_invited_user = InvitedUser.query.get(sample_invited_user.id)
     assert cancelled_invited_user.status == InvitedUserStatus.CANCELLED
 

--- a/tests/app/dao/test_service_guest_list_dao.py
+++ b/tests/app/dao/test_service_guest_list_dao.py
@@ -1,5 +1,8 @@
 import uuid
 
+from sqlalchemy import func, select
+
+from app import db
 from app.dao.service_guest_list_dao import (
     dao_add_and_commit_guest_list_contacts,
     dao_fetch_service_guest_list,
@@ -27,7 +30,8 @@ def test_add_and_commit_guest_list_contacts_saves_data(sample_service):
 
     dao_add_and_commit_guest_list_contacts([guest_list])
 
-    db_contents = ServiceGuestList.query.all()
+    stmt = select(ServiceGuestList)
+    db_contents = db.session.execute(stmt).scalars().all()
     assert len(db_contents) == 1
     assert db_contents[0].id == guest_list.id
 
@@ -60,4 +64,6 @@ def test_remove_service_guest_list_does_not_commit(
     # since dao_remove_service_guest_list doesn't commit, we can still rollback its changes
     notify_db_session.rollback()
 
-    assert ServiceGuestList.query.count() == 1
+    stmt = select(func.count()).select_from(ServiceGuestList)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 1

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -2,6 +2,8 @@ import random
 import uuid
 from datetime import datetime, timedelta
 
+from sqlalchemy import select
+
 from app import db
 from app.dao import fact_processing_time_dao
 from app.dao.email_branding_dao import dao_create_email_branding
@@ -90,7 +92,8 @@ def create_user(
         "state": state,
         "platform_admin": platform_admin,
     }
-    user = User.query.filter_by(email_address=email).first()
+    stmt = select(User).where(User.email_address == email)
+    user = db.session.execute(stmt).scalars().first()
     if not user:
         user = User(**data)
     save_model_user(user, validated_email_access=True)
@@ -130,7 +133,8 @@ def create_service(
     billing_reference=None,
 ):
     if check_if_service_exists:
-        service = Service.query.filter_by(name=service_name).first()
+        stmt = select(Service).where(Service.name == service_name)
+        service = db.session.execute(stmt).scalars().first()
     if (not check_if_service_exists) or (check_if_service_exists and not service):
         service = Service(
             name=service_name,
@@ -175,7 +179,8 @@ def create_service(
 def create_service_with_inbound_number(inbound_number="1234567", *args, **kwargs):
     service = create_service(*args, **kwargs)
 
-    sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).first()
+    stmt = select(ServiceSmsSender).where(ServiceSmsSender.service_id == service.id)
+    sms_sender = db.session.execute(stmt).scalars().first()
     inbound = create_inbound_number(number=inbound_number, service_id=service.id)
     update_existing_sms_sender_with_inbound_number(
         service_sms_sender=sms_sender,
@@ -189,7 +194,8 @@ def create_service_with_inbound_number(inbound_number="1234567", *args, **kwargs
 def create_service_with_defined_sms_sender(sms_sender_value="1234567", *args, **kwargs):
     service = create_service(*args, **kwargs)
 
-    sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).first()
+    stmt = select(ServiceSmsSender).where(ServiceSmsSender.service_id == service.id)
+    sms_sender = db.session.execute(stmt).scalars().first()
     dao_update_service_sms_sender(
         service_id=service.id,
         service_sms_sender_id=sms_sender.id,
@@ -286,9 +292,10 @@ def create_notification(
 
     if not one_off and (job is None and api_key is None):
         # we did not specify in test - lets create it
-        api_key = ApiKey.query.filter(
+        stmt = select(ApiKey).where(
             ApiKey.service == template.service, ApiKey.key_type == key_type
-        ).first()
+        )
+        api_key = db.session.execute(stmt).scalars().first()
         if not api_key:
             api_key = create_api_key(template.service, key_type=key_type)
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -5,8 +5,10 @@ from collections import namedtuple
 import pytest
 from boto3.exceptions import Boto3Error
 from freezegun import freeze_time
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 
+from app import db
 from app.enums import KeyType, NotificationType, ServicePermissionType, TemplateType
 from app.errors import BadRequestError
 from app.models import Notification, NotificationHistory
@@ -67,12 +69,22 @@ def test_create_content_for_notification_allows_additional_personalisation(
     )
 
 
+def _get_notification_query_count():
+    stmt = select(func.count()).select_from(Notification)
+    return db.session.execute(stmt).scalar() or 0
+
+
+def _get_notification_history_query_count():
+    stmt = select(func.count()).select_from(NotificationHistory)
+    return db.session.execute(stmt).scalar() or 0
+
+
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_creates_and_save_to_db(
     sample_template, sample_api_key, sample_job
 ):
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    assert _get_notification_query_count() == 0
+    assert _get_notification_history_query_count() == 0
     notification = persist_notification(
         template_id=sample_template.id,
         template_version=sample_template.version,
@@ -114,8 +126,8 @@ def test_persist_notification_creates_and_save_to_db(
 
 
 def test_persist_notification_throws_exception_when_missing_template(sample_api_key):
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    assert _get_notification_query_count() == 0
+    assert _get_notification_history_query_count() == 0
     with pytest.raises(SQLAlchemyError):
         persist_notification(
             template_id=None,
@@ -127,14 +139,14 @@ def test_persist_notification_throws_exception_when_missing_template(sample_api_
             api_key_id=sample_api_key.id,
             key_type=sample_api_key.key_type,
         )
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    assert _get_notification_query_count() == 0
+    assert _get_notification_history_query_count() == 0
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_with_optionals(sample_job, sample_api_key):
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    assert _get_notification_query_count() == 0
+    assert _get_notification_history_query_count() == 0
     n_id = uuid.uuid4()
     created_at = datetime.datetime(2016, 11, 11, 16, 8, 18)
     persist_notification(
@@ -153,9 +165,10 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key):
         notification_id=n_id,
         created_by_id=sample_job.created_by_id,
     )
-    assert Notification.query.count() == 1
-    assert NotificationHistory.query.count() == 0
-    persisted_notification = Notification.query.all()[0]
+    assert _get_notification_query_count() == 1
+    assert _get_notification_history_query_count() == 0
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
     assert persisted_notification.id == n_id
     assert persisted_notification.job_id == sample_job.id
     assert persisted_notification.job_row_number == 10
@@ -267,8 +280,8 @@ def test_send_notification_to_queue_throws_exception_deletes_notification(
         queue="send-sms-tasks",
     )
 
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    assert _get_notification_query_count() == 0
+    assert _get_notification_history_query_count() == 0
 
 
 @pytest.mark.parametrize(
@@ -349,7 +362,8 @@ def test_persist_notification_with_international_info_stores_correct_info(
         job_row_number=10,
         client_reference="ref from client",
     )
-    persisted_notification = Notification.query.all()[0]
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
 
     assert persisted_notification.international is expected_international
     assert persisted_notification.phone_prefix == expected_prefix
@@ -372,7 +386,8 @@ def test_persist_notification_with_international_info_does_not_store_for_email(
         job_row_number=10,
         client_reference="ref from client",
     )
-    persisted_notification = Notification.query.all()[0]
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
 
     assert persisted_notification.international is False
     assert persisted_notification.phone_prefix is None
@@ -404,7 +419,8 @@ def test_persist_sms_notification_stores_normalised_number(
         key_type=sample_api_key.key_type,
         job_id=sample_job.id,
     )
-    persisted_notification = Notification.query.all()[0]
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
 
     assert persisted_notification.to == "1"
     assert persisted_notification.normalised_to == "1"
@@ -428,7 +444,8 @@ def test_persist_email_notification_stores_normalised_email(
         key_type=sample_api_key.key_type,
         job_id=sample_job.id,
     )
-    persisted_notification = Notification.query.all()[0]
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
 
     assert persisted_notification.to == "1"
     assert persisted_notification.normalised_to == "1"
@@ -449,6 +466,7 @@ def test_persist_notification_with_billable_units_stores_correct_info(mocker):
         key_type=KeyType.NORMAL,
         billable_units=3,
     )
-    persisted_notification = Notification.query.all()[0]
+    stmt = select(Notification)
+    persisted_notification = db.session.execute(stmt).scalars().all()[0]
 
     assert persisted_notification.billable_units == 3

--- a/tests/app/organization/test_rest.py
+++ b/tests/app/organization/test_rest.py
@@ -4,8 +4,10 @@ from unittest.mock import Mock
 import pytest
 from flask import current_app
 from freezegun import freeze_time
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
+from app import db
 from app.dao.organization_dao import (
     dao_add_service_to_organization,
     dao_add_user_to_organization,
@@ -175,7 +177,7 @@ def test_post_create_organization(admin_request, notify_db_session):
         "organization.create_organization", _data=data, _expected_status=201
     )
 
-    organizations = Organization.query.all()
+    organizations = _get_organizations()
 
     assert data["name"] == response["name"]
     assert data["active"] == response["active"]
@@ -184,6 +186,11 @@ def test_post_create_organization(admin_request, notify_db_session):
     assert len(organizations) == 1
     # check that for non-nhs orgs, default branding is not set
     assert organizations[0].email_branding_id is None
+
+
+def _get_organizations():
+    stmt = select(Organization)
+    return db.session.execute(stmt).scalars().all()
 
 
 @pytest.mark.parametrize("org_type", ["nhs_central", "nhs_local", "nhs_gp"])
@@ -201,7 +208,7 @@ def test_post_create_organization_sets_default_nhs_branding_for_nhs_orgs(
         "organization.create_organization", _data=data, _expected_status=201
     )
 
-    organizations = Organization.query.all()
+    organizations = _get_organizations()
 
     assert len(organizations) == 1
     assert organizations[0].email_branding_id == uuid.UUID(
@@ -212,7 +219,7 @@ def test_post_create_organization_sets_default_nhs_branding_for_nhs_orgs(
 def test_post_create_organization_existing_name_raises_400(
     admin_request, sample_organization
 ):
-    organization = Organization.query.all()
+    organization = _get_organizations()
     assert len(organization) == 1
 
     data = {
@@ -225,14 +232,14 @@ def test_post_create_organization_existing_name_raises_400(
         "organization.create_organization", _data=data, _expected_status=400
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 1
     assert response["message"] == "Organization name already exists"
 
 
 def test_post_create_organization_works(admin_request, sample_organization):
-    organization = Organization.query.all()
+    organization = _get_organizations()
     assert len(organization) == 1
 
     data = {
@@ -245,7 +252,7 @@ def test_post_create_organization_works(admin_request, sample_organization):
         "organization.create_organization", _data=data, _expected_status=201
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 2
 
@@ -310,7 +317,7 @@ def test_post_update_organization_updates_fields(
         _expected_status=204,
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 1
     assert organization[0].id == org.id
@@ -343,7 +350,7 @@ def test_post_update_organization_updates_domains(
         _expected_status=204,
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 1
     assert [domain.domain for domain in organization[0].domains] == domain_list
@@ -383,7 +390,7 @@ def test_post_update_organization_to_nhs_type_updates_branding_if_none_present(
         _expected_status=204,
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 1
     assert organization[0].id == org.id
@@ -413,7 +420,7 @@ def test_post_update_organization_to_nhs_type_does_not_update_branding_if_defaul
         _expected_status=204,
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert len(organization) == 1
     assert organization[0].id == org.id
@@ -471,7 +478,7 @@ def test_post_update_organization_gives_404_status_if_org_does_not_exist(
         _expected_status=404,
     )
 
-    organization = Organization.query.all()
+    organization = _get_organizations()
 
     assert not organization
 

--- a/tests/app/service/send_notification/test_send_notification.py
+++ b/tests/app/service/send_notification/test_send_notification.py
@@ -5,8 +5,10 @@ import pytest
 from flask import current_app, json
 from freezegun import freeze_time
 from notifications_python_client.authentication import create_jwt_token
+from sqlalchemy import func, select
 
 import app
+from app import db
 from app.dao import notifications_dao
 from app.dao.api_key_dao import save_model_api_key
 from app.dao.services_dao import dao_update_service
@@ -883,7 +885,9 @@ def test_should_not_persist_notification_or_send_email_if_simulated_email(
 
     assert response.status_code == 201
     apply_async.assert_not_called()
-    assert Notification.query.count() == 0
+    stmt = select(func.count()).select_from(Notification)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 0
 
 
 @pytest.mark.parametrize("to_sms", ["+14254147755", "+14254147167"])
@@ -906,7 +910,10 @@ def test_should_not_persist_notification_or_send_sms_if_simulated_number(
 
     assert response.status_code == 201
     apply_async.assert_not_called()
-    assert Notification.query.count() == 0
+
+    stmt = select(func.count()).select_from(Notification)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 0
 
 
 @pytest.mark.parametrize("key_type", [KeyType.NORMAL, KeyType.TEAM])

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -1,6 +1,8 @@
 import pytest
 from flask import current_app
+from sqlalchemy import func, select
 
+from app import db
 from app.dao.services_dao import dao_add_user_to_service
 from app.enums import NotificationType, TemplateType
 from app.models import Notification
@@ -23,7 +25,9 @@ def test_send_notification_to_service_users_persists_notifications_correctly(
 
     notification = Notification.query.one()
 
-    assert Notification.query.count() == 1
+    stmt = select(func.count()).select_from(Notification)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 1
     assert notification.to == "1"
     assert str(notification.service_id) == current_app.config["NOTIFY_SERVICE_ID"]
     assert notification.template.id == template.id
@@ -89,4 +93,6 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
 
     send_notification_to_service_users(service_id=service.id, template_id=template.id)
 
-    assert Notification.query.count() == 2
+    stmt = select(func.count()).select_from(Notification)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 2

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -6,7 +6,9 @@ from datetime import datetime, timedelta
 
 import pytest
 from freezegun import freeze_time
+from sqlalchemy import select
 
+from app import db
 from app.dao.templates_dao import dao_get_template_by_id, dao_redact_template
 from app.enums import ServicePermissionType, TemplateProcessType, TemplateType
 from app.models import Template, TemplateHistory
@@ -86,7 +88,8 @@ def test_create_a_new_template_for_a_service_adds_folder_relationship(
         data=data,
     )
     assert response.status_code == 201
-    template = Template.query.filter(Template.name == "my template").first()
+    stmt = select(Template).where(Template.name == "my template")
+    template = db.session.execute(stmt).scalars().first()
     assert template.folder == parent_folder
 
 

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -1,7 +1,9 @@
 import uuid
 
 import pytest
+from sqlalchemy import func, select
 
+from app import db
 from app.dao.service_user_dao import dao_get_service_user
 from app.models import TemplateFolder
 from tests.app.db import (
@@ -286,7 +288,9 @@ def test_delete_template_folder_fails_if_folder_has_subfolders(
 
     assert resp == {"result": "error", "message": "Folder is not empty"}
 
-    assert TemplateFolder.query.count() == 2
+    stmt = select(func.count()).select_from(TemplateFolder)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 2
 
 
 def test_delete_template_folder_fails_if_folder_contains_templates(
@@ -304,7 +308,9 @@ def test_delete_template_folder_fails_if_folder_contains_templates(
 
     assert resp == {"result": "error", "message": "Folder is not empty"}
 
-    assert TemplateFolder.query.count() == 1
+    stmt = select(func.count()).select_from(TemplateFolder)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -372,11 +372,10 @@ def test_populate_annual_billing_with_defaults_sets_free_allowance_to_zero_if_pr
         populate_annual_billing_with_defaults, ["-y", 2022]
     )
 
-    stmt = select(AnnualBilling).where(
+    results = AnnualBilling.query.filter(
         AnnualBilling.financial_year_start == 2022,
         AnnualBilling.service_id == service.id,
-    )
-    results = db.session.execute(stmt).scalars().all()
+    ).all()
 
     assert len(results) == 1
     assert results[0].free_sms_fragment_limit == 0

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -418,7 +418,7 @@ def test_create_service_command(notify_db_session, notify_api):
     assert Service.query.count() == service_count + 1
 
     # that service should be the one we added
-    stmt = select(Service).where(name="Fake Service")
+    stmt = select(Service).where(Service.name == "Fake Service")
     service = db.session.execute(stmt).first()
     assert service.email_from == "somebody@fake.gov"
     assert service.restricted is False

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -414,17 +414,20 @@ def test_create_service_command(notify_db_session, notify_api):
 
     user = User.query.first()
 
-    service_count = Service.query.count()
+    stmt = select(func.count()).select_from(Service)
+    service_count = db.session.execute(stmt).scalar() or 0
 
     # run the command
-    result = notify_api.test_cli_runner().invoke(
+    notify_api.test_cli_runner().invoke(
         create_new_service,
         ["-e", "somebody@fake.gov", "-n", "Fake Service", "-c", user.id],
     )
-    print(result)
 
     # there should be one more service
-    assert Service.query.count() == service_count + 1
+
+    stmt = select(func.count()).select_from(Service)
+    count = db.session.execute(stmt).scalar() or 0
+    assert count == service_count + 1
 
     # that service should be the one we added
     stmt = select(Service).where(Service.name == "Fake Service")

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -142,7 +142,7 @@ def test_update_jobs_archived_flag(notify_db_session, notify_api):
 
 
 def _get_organization_query_count():
-    stmt = select(Organization)
+    stmt = select(func.count()).select_from(Organization)
     return db.session.execute(stmt).scalar() or 0
 
 

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -246,7 +246,7 @@ def test_create_test_user_command(notify_db_session, notify_api):
 
     # that user should be the one we added
     stmt = select(User).where(User.name == "Fake Personson")
-    user = db.session.execute(stmt).first()
+    user = db.session.execute(stmt).scalars().first()
     assert user.email_address == "somebody@fake.gov"
     assert user.auth_type == AuthType.SMS
     assert user.state == "active"

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -118,7 +118,7 @@ def test_update_jobs_archived_flag(notify_db_session, notify_api):
     tomorrow = tomorrow.strftime("%Y-%m-%d")
 
     stmt = select(Job).where(Job.archived is True)
-    archived_jobs = db.session.execute(stmt).scalar()
+    archived_jobs = db.session.execute(stmt).scalar() or 0
     assert archived_jobs == 0
 
     notify_api.test_cli_runner().invoke(
@@ -245,7 +245,7 @@ def test_create_test_user_command(notify_db_session, notify_api):
     assert User.query.count() == user_count + 1
 
     # that user should be the one we added
-    stmt = select(User).where(name="Fake Personson")
+    stmt = select(User).where(User.name == "Fake Personson")
     user = db.session.execute(stmt).first()
     assert user.email_address == "somebody@fake.gov"
     assert user.auth_type == AuthType.SMS
@@ -419,7 +419,7 @@ def test_create_service_command(notify_db_session, notify_api):
 
     # that service should be the one we added
     stmt = select(Service).where(Service.name == "Fake Service")
-    service = db.session.execute(stmt).first()
+    service = db.session.execute(stmt).scalars().first()
     assert service.email_from == "somebody@fake.gov"
     assert service.restricted is False
     assert service.message_limit == 40000

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -336,7 +336,8 @@ def test_post_user_attribute_with_updated_by_sends_notification_to_international
         _data=update_dict,
     )
 
-    notification = Notification.query.first()
+    stmt = select(Notification)
+    notification = db.session.execute(stmt).scalars().first()
     assert (
         notification.reply_to_text
         == current_app.config["NOTIFY_INTERNATIONAL_SMS_SENDER"]
@@ -526,7 +527,9 @@ def test_set_user_permissions_remove_old(admin_request, sample_user, sample_serv
     )
     count = db.session.execute(query).scalar() or 0
     assert count == 1
-    assert query.first().permission == PermissionType.MANAGE_SETTINGS
+    query = select(Permission).where(Permission.user == sample_user)
+    first_permission = db.session.execute(query).scalars().first()
+    assert first_permission.permission == PermissionType.MANAGE_SETTINGS
 
 
 def test_set_user_folder_permissions(admin_request, sample_user, sample_service):
@@ -658,7 +661,8 @@ def test_send_already_registered_email(
         _expected_status=204,
     )
 
-    notification = Notification.query.first()
+    stmt = select(Notification)
+    notification = db.session.execute(stmt).scalars().first()
     mocked.assert_called_once_with(
         ([str(notification.id)]), queue="notify-internal-tasks"
     )
@@ -696,8 +700,8 @@ def test_send_user_confirm_new_email_returns_204(
         _data=data,
         _expected_status=204,
     )
-
-    notification = Notification.query.first()
+    stmt = select(Notification)
+    notification = db.session.execute(stmt).scalars().first()
     mocked.assert_called_once_with(
         ([str(notification.id)]), queue="notify-internal-tasks"
     )

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -6,7 +6,9 @@ from unittest import mock
 import pytest
 from flask import current_app
 from freezegun import freeze_time
+from sqlalchemy import func, select
 
+from app import db
 from app.dao.service_user_dao import dao_get_service_user, dao_update_service_user
 from app.enums import AuthType, KeyType, NotificationType, PermissionType
 from app.models import Notification, Permission, User
@@ -153,10 +155,15 @@ def test_post_user_missing_attribute_email(admin_request, notify_db_session):
     }
     json_resp = admin_request.post("user.create_user", _data=data, _expected_status=400)
 
-    assert User.query.count() == 0
+    assert _get_user_count() == 0
     assert {"email_address": ["Missing data for required field."]} == json_resp[
         "message"
     ]
+
+
+def _get_user_count():
+    stmt = select(func.count()).select_from(User)
+    return db.session.execute(stmt).scalar() or 0
 
 
 def test_create_user_missing_attribute_password(admin_request, notify_db_session):
@@ -174,7 +181,7 @@ def test_create_user_missing_attribute_password(admin_request, notify_db_session
         "permissions": {},
     }
     json_resp = admin_request.post("user.create_user", _data=data, _expected_status=400)
-    assert User.query.count() == 0
+    assert _get_user_count() == 0
     assert {"password": ["Missing data for required field."]} == json_resp["message"]
 
 
@@ -512,8 +519,13 @@ def test_set_user_permissions_remove_old(admin_request, sample_user, sample_serv
         _expected_status=204,
     )
 
-    query = Permission.query.filter_by(user=sample_user)
-    assert query.count() == 1
+    query = (
+        select(func.count())
+        .select_from(Permission)
+        .where(Permission.user == sample_user)
+    )
+    count = db.session.execute(query).scalar() or 0
+    assert count == 1
     assert query.first().permission == PermissionType.MANAGE_SETTINGS
 
 


### PR DESCRIPTION
## Description

Fix some of the remaining sqlalchemy 1.4 implementations in queries.  I'm using this to count:

grep -ri "query\." | wc -l

and it currently gives a count of 307.  I think at least 50 of that is false positives, but still there is more work to be done.  However this PR is quite big so might as well get it checked in.


## Security Considerations

N/A