### PR TITLE
Make sandbox deployments easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ var/
 .installed.cfg
 *.egg
 /cache
+requirements.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/deploy-config/sandbox.yml
+++ b/deploy-config/sandbox.yml
@@ -9,5 +9,10 @@ admin_base_url: https://notify-sandbox.app.cloud.gov
 redis_enabled: 1
 default_toll_free_number: "+18885989205"
 ADMIN_CLIENT_SECRET: sandbox-notify-secret-key
+API_HOST_NAME: https://notify-api-sandbox.app.cloud.gov
 DANGEROUS_SALT: sandbox-notify-salt
+LOGIN_DOT_GOV_REGISTRATION_URL: https://idp.int.identitysandbox.gov/openid_connect/authorize?acr_values=http%3A%2F%2Fidmanagement.gov%2Fns%2Fassurance%2Fial%2F1&client_id=urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:test_notify_gov&nonce=NONCE&prompt=select_account&redirect_uri=https://notify-sandbox.app.cloud.gov/set-up-your-profile&response_type=code&scope=openid+email&state=STATE
+NEW_RELIC_LICENSE_KEY: ""
+NOTIFY_E2E_TEST_EMAIL: fake.user@example.com
+NOTIFY_E2E_TEST_PASSWORD: "don't write secrets to the sample file"
 SECRET_KEY: sandbox-notify-secret-key

--- a/docs/all.md
+++ b/docs/all.md
@@ -443,22 +443,44 @@ Rules for use:
    - Delete the apps and routes shown in `cf apps` by running `cf delete APP_NAME -r`
    - Delete the space deployer you created by following the instructions within `terraform/sandbox/secrets.auto.tfvars`
 
-### Deploying to the sandbox
+### Setting up the sandbox infrastructure
 
 If this is the first time you have used Terraform in this repository, you will first have to hook your copy of Terraform up to our remote state. Follow [Retrieving existing bucket credentials](https://github.com/GSA/notifications-api/tree/main/terraform#retrieving-existing-bucket-credentials).
 
 :anchor: The Admin app depends upon the API app, so set up the API first.
 
 1. Set up services:
-   ```bash
-   $ cd terraform/sandbox
-   $ ../create_service_account.sh -s notify-sandbox -u <your-name>-terraform -m > secrets.auto.tfvars
-   $ terraform init
-   $ terraform plan
-   $ terraform apply
-   ```
-   Check [Terraform troubleshooting](https://github.com/GSA/notifications-api/tree/main/terraform#troubleshooting) if you encounter problems.
-1. Change back to the project root directory: `cd ../..`
+    ```bash
+    $ cd terraform/sandbox
+    $ ../create_service_account.sh -s notify-sandbox -u <your-name>-terraform -m > secrets.auto.tfvars
+    $ terraform init
+    $ terraform plan
+    $ terraform apply
+    ```
+    Check [Terraform troubleshooting](https://github.com/GSA/notifications-api/tree/main/terraform#troubleshooting) if you encounter problems.
+
+Note that you'll have to do this for both the API and the Admin.  Once this is complete we shouldn't have to do it again (unless we're setting up a new sandbox environment).
+
+### Deploying to the sandbox
+
+To deploy either the API or the Admin apps to the sandbox, the process is largely the same, but the Admin requires a bit of additional work.
+
+#### Deploying the API to the sandbox
+
+1. Make sure you are in the API project's root directory.
+1. Authenticate with cloud.gov in the command line: `cf login -a api.fr.cloud.gov --sso`
+1. Run `./scripts/deploy_to_sandbox.sh` from the project root directory.
+
+At this point your target org and space will change with cloud.gov to be the `notify-sandbox` environment and the application will be pushed for deployment.
+
+The script does a few things to make sure the deployment flows smoothly with miniminal work on your part:
+
+* Sets the target org and space in cloud.gov for you.
+* Creates a `requirements.txt` file for the Python dependencies so that the deployment picks up on the dependencies properly.
+* Pushes the application with the correct environment variables set based on what is supplied by the `deploy-config/sandbox.yml` file.
+
+#### Deploying the Admin to the sandbox
+
 1. Start a poetry shell as a shortcut to load `.env` file variables by running `poetry shell`. (You'll have to restart this any time you change the file.)
 1. Output requirements.txt file: `poetry export --without-hashes --format=requirements.txt > requirements.txt`
 1. Ensure you are using the correct CloudFoundry target

--- a/scripts/deploy_to_sandbox.sh
+++ b/scripts/deploy_to_sandbox.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create a requirements.txt file so dependencies are properly managed with the
+# deploy.  This will overwrite any existing requirements.txt file to make sure
+# it is always up-to-date.
+poetry export --without-hashes --format=requirements.txt > requirements.txt
+
+# Target the notify-sandbox space and deploy to cloud.gov with a cf push.
+# All environment variables are accounted for in the deploy-config/sandbox.yml
+# file, no need to add any of your own or source a .env* file.
+
+# If ithis errors out because you need to be logged in, login first with this:
+# cf login -a api.fr.cloud.gov --sso
+cf target -o gsa-tts-benefits-studio -s notify-sandbox
+cf push -f manifest.yml --vars-file deploy-config/staging.yml --strategy rolling

--- a/scripts/deploy_to_sandbox.sh
+++ b/scripts/deploy_to_sandbox.sh
@@ -9,7 +9,7 @@ poetry export --without-hashes --format=requirements.txt > requirements.txt
 # All environment variables are accounted for in the deploy-config/sandbox.yml
 # file, no need to add any of your own or source a .env* file.
 
-# If ithis errors out because you need to be logged in, login first with this:
+# If this errors out because you need to be logged in, login first with this:
 # cf login -a api.fr.cloud.gov --sso
 cf target -o gsa-tts-benefits-studio -s notify-sandbox
-cf push -f manifest.yml --vars-file deploy-config/staging.yml --strategy rolling
+cf push -f manifest.yml --vars-file deploy-config/sandbox.yml --strategy rolling


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset makes a few adjustments to our sandbox environment config to make the sandbox deployments of the API much easier.  It does this with the following:
    
* Adds a few environment variable values to the sandbox.yml file to cover the ones that were not there previously
* Adds a new script that can be run in place of memorizing any commands
* Adds documentation on how to configure and run the sandbox environment

## Security Considerations

* We still need to be mindful of environment variables and not sharing sensitive credentials/secrets.
* This helps make the management of the environment variables much easier for sandbox deployment.