### PR TITLE
reduce number of pool connections

### DIFF
--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -16,7 +16,9 @@ AWS_CLIENT_CONFIG = Config(
     # This is the default but just for doc sake
     # there may come a time when increasing this helps
     # with job cache management.
-    max_pool_connections=10,
+    # max_pool_connections=10,
+    # Reducing to 4 connections due to BrokenPipeErrors
+    max_pool_connections=4,
 )
 
 


### PR DESCRIPTION
## Description

We saw some BrokenPipeErrors that caused messages not to be sent.  Some of the stack traces pointed in the direction of multiprocessing.Manager, which handles downloading S3 objects to build up our jobs cache.

One recommendation when seeing BrokenPipeError is to reduce the number of connections in the connection pool, and that is the easiest fix to try.

Others are:

1. Increase memory and CPU
2. Use more retry logic (yuck)
3. Consider replacing multiprocessing.Manager with multiprocessing.Queue or Pipe

NOTE:  The [`multiprocessing.Manager`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Manager) is used in app/aws/s3.py and the whole cache-building workflow also relies on concurrent.futures.ThreadPoolExecutor.  Both rely on the AWS_CLIENT_CONFIG, which defines the maximum number of pool connections.

## Security Considerations

N/A