### PR TITLE
Verify state for login.gov

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -52,21 +52,14 @@ def get_login_gov_user(login_uuid, email_address):
                 current_app.logger.exception("Error getting login.gov user")
                 db.session.rollback()
 
-        print("In here instead!")
         return user
     # Remove this 1 July 2025, all users should have login.gov uuids by now
     stmt = select(User).filter(User.email_address.ilike(email_address))
     user = db.session.execute(stmt).scalars().first()
 
-    print("*" * 80)
-    print(user)
-
     if user:
-        print(f"login_uuid: {login_uuid}")
         save_user_attribute(user, {"login_uuid": login_uuid})
         return user
-
-    print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% WTF")
 
     return None
 

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -52,14 +52,21 @@ def get_login_gov_user(login_uuid, email_address):
                 current_app.logger.exception("Error getting login.gov user")
                 db.session.rollback()
 
+        print("In here instead!")
         return user
     # Remove this 1 July 2025, all users should have login.gov uuids by now
     stmt = select(User).filter(User.email_address.ilike(email_address))
     user = db.session.execute(stmt).scalars().first()
 
+    print("*" * 80)
+    print(user)
+
     if user:
+        print(f"login_uuid: {login_uuid}")
         save_user_attribute(user, {"login_uuid": login_uuid})
         return user
+
+    print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% WTF")
 
     return None
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -373,7 +373,7 @@ def add_user_to_service(service_id, user_id):
     service = dao_fetch_service_by_id(service_id)
     user = get_user_by_id(user_id=user_id)
     if user in service.users:
-        error = "User id: {} already part of service id: {}".format(user_id, service_id)
+        error = f"User id: {user_id} already part of service id: {service_id}"
         raise InvalidRequest(error, status_code=400)
 
     data = request.get_json()

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -155,6 +155,9 @@ def resend_service_invite(service_id, invited_user_id):
         invited_user_id=invited_user_id,
     )
 
+    nonce = request.json["nonce"]
+    state = request.json["state"]
+
     fetched.created_at = utc_now()
     fetched.status = InvitedUserStatus.PENDING
 
@@ -163,7 +166,7 @@ def resend_service_invite(service_id, invited_user_id):
 
     save_invited_user(update_dict)
 
-    _create_service_invite(fetched, current_app.config["ADMIN_BASE_URL"])
+    _create_service_invite(fetched, nonce, state)
 
     return jsonify(data=invited_user_schema.dump(fetched)), 200
 

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -87,6 +87,8 @@ def _create_service_invite(invited_user, nonce, state):
     )
     send_notification_to_queue(saved_notification, queue=QueueNames.NOTIFY)
 
+    return data
+
 
 @service_invite.route("/service/<service_id>/invite", methods=["POST"])
 def create_invited_user(service_id):
@@ -105,9 +107,9 @@ def create_invited_user(service_id):
     invited_user = invited_user_schema.load(request_json)
     save_invited_user(invited_user)
 
-    _create_service_invite(invited_user, nonce, state)
+    invite_data = _create_service_invite(invited_user, nonce, state)
 
-    return jsonify(data=invited_user_schema.dump(invited_user)), 201
+    return jsonify(data=invited_user_schema.dump(invited_user), invite=invite_data), 201
 
 
 @service_invite.route("/service/<service_id>/invite/expired", methods=["GET"])

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -56,8 +56,6 @@ def _create_service_invite(invited_user, nonce, state):
 
     url = url.replace("NONCE", nonce)  # handed from data sent from admin.
 
-    user_data_url_safe = get_user_data_url_safe(data)
-
     url = url.replace("STATE", state)
 
     personalisation = {
@@ -216,9 +214,3 @@ def validate_service_invitation_token(token):
 
     invited_user = get_invited_user_by_id(invited_user_id)
     return jsonify(data=invited_user_schema.dump(invited_user)), 200
-
-
-def get_user_data_url_safe(data):
-    data = json.dumps(data)
-    data = base64.b64encode(data.encode("utf8"))
-    return data.decode("utf8")

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import os
 

--- a/tests/app/service_invite/test_service_invite_rest.py
+++ b/tests/app/service_invite/test_service_invite_rest.py
@@ -46,6 +46,7 @@ def test_create_invited_user(
         auth_type=AuthType.EMAIL,
         folder_permissions=["folder_1", "folder_2", "folder_3"],
         nonce="FakeNonce",
+        state="FakeState",
         **extra_args,
     )
 
@@ -110,6 +111,7 @@ def test_create_invited_user_without_auth_type(
         "permissions": "send_messages,manage_service,manage_api_keys",
         "folder_permissions": [],
         "nonce": "FakeNonce",
+        "state": "FakeState",
     }
 
     json_resp = admin_request.post(
@@ -134,6 +136,7 @@ def test_create_invited_user_invalid_email(client, sample_service, mocker, fake_
         "permissions": "send_messages,manage_service,manage_api_keys",
         "folder_permissions": [fake_uuid, fake_uuid],
         "nonce": "FakeNonce",
+        "state": "FakeState",
     }
 
     data = json.dumps(data)
@@ -235,6 +238,7 @@ def test_resend_expired_invite(
     response = client.post(
         url,
         headers=[("Content-Type", "application/json"), auth_header],
+        data='{"nonce": "FakeNonce", "state": "FakeState"}',
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

the state was largely unused by our system, and was seen as a necessity for working with login.gov. Now we are checking that the state is correct on return from login.gov. It is sent as a query parameter back from login.gov, and we are now simply checking that it matches a value we have stored in redis.

This also is now generated from the admin, and then passed into the api endpoints for both creating a new invitation, and resending an expired invitation. As such, everything from login.gov is now checked for both state and nonce (the previous work I had done). This will help eliminate possible ingresses from bad actors.

https://github.com/GSA/us-notify-compliance/issues/51

This must only be merged when both this ticket and the one linked here is finished: https://github.com/GSA/notifications-admin/pull/2075

## Security Considerations

Checking state, like nonce, is important for the security of the login process.