### PR TITLE
set max_pool_connections to 7

### DIFF
--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -17,8 +17,8 @@ AWS_CLIENT_CONFIG = Config(
     # there may come a time when increasing this helps
     # with job cache management.
     # max_pool_connections=10,
-    # Reducing to 4 connections due to BrokenPipeErrors
-    max_pool_connections=4,
+    # Reducing to 7 connections due to BrokenPipeErrors
+    max_pool_connections=7,
 )
 
 


### PR DESCRIPTION
This is changing the `max_pool_connections` after our memory bump, trying to find the right level for application stability.