### PR TITLE
Moving the Job Cache to the flask app's config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import string
 import time
 import uuid
 from contextlib import contextmanager
+from multiprocessing import Manager
 from time import monotonic
 
 from celery import Celery, Task, current_task
@@ -118,6 +119,9 @@ def create_app(application):
     encryption.init_app(application)
     redis_store.init_app(application)
     document_download_client.init_app(application)
+
+    manager = Manager()
+    application.config["job_cache"] = manager.dict()
 
     register_blueprint(application)
 


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This should hopefully help address the breaking issues we are seeing in API. the effort is to make the multiprocessing manager's dict instance that is used for the job cache be created only once, with the theory that some of the issues, if not most of them, are being caused by a confusion in the code with regards to the job_cache queue.

## Security Considerations

None I can think of at this time.