### PR TITLE
Bump production app memory to 3 GB

### DIFF
--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -1,6 +1,6 @@
 env: production
 web_instances: 2
-web_memory: 2G
+web_memory: 3G
 worker_instances: 4
 worker_memory: 3G
 scheduler_memory: 256M


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset bumps our production app memory for the API to 3 GB available in anticipation of the shift of the job cache being managed by the application itself instead of a worker process.

## Security Considerations

* This will help keep our API stable by ensuring there's enough memory available.  If we find we don't need it, we can tune it back down in the future.