### PR TITLE
Adjust Celery worker memory

### DIFF
--- a/deploy-config/production.yml
+++ b/deploy-config/production.yml
@@ -2,7 +2,7 @@ env: production
 web_instances: 2
 web_memory: 3G
 worker_instances: 4
-worker_memory: 3G
+worker_memory: 2G
 scheduler_memory: 256M
 public_api_route: notify-api.app.cloud.gov
 admin_base_url: https://beta.notify.gov


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

The Celery workers are not using as much memory as we had been anticipating, and we are also hitting our memory quota.  This adjusts them down a bit to free up a bit more.

## Security Considerations

* N/A with this change.