### PR TITLE
put max connections back to 10

### DIFF
--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -14,11 +14,7 @@ AWS_CLIENT_CONFIG = Config(
     },
     use_fips_endpoint=True,
     # This is the default but just for doc sake
-    # there may come a time when increasing this helps
-    # with job cache management.
-    # max_pool_connections=10,
-    # Reducing to 7 connections due to BrokenPipeErrors
-    max_pool_connections=7,
+    max_pool_connections=10,
 )
 
 


### PR DESCRIPTION
## Description

Reducing the max connection count below the default of 10 seems to be destabilizing.  Put it back to the default.

## Security Considerations

N/A