### PR TITLE
adjust worker lifetime

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -166,7 +166,7 @@ class Config(object):
     current_minute = (datetime.now().minute + 1) % 60
 
     CELERY = {
-        "worker_max_tasks_per_child": 20,
+        "worker_max_tasks_per_child": 200,
         "broker_url": REDIS_URL,
         "broker_transport_options": {
             "visibility_timeout": 310,


### PR DESCRIPTION
## Description

We set worker max tasks to 20 but this is causing too much worker churn.  Let's try 200 tasks per worker.

## Security Considerations

N/A