### PR TITLE
Add redis ID to ignore vulnerability list in pip-audit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -90,6 +90,8 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.8
         with:
           inputs: requirements.txt
+          ignore-vulns: |
+            PYSEC-2022-43162
 
   static-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a Python vulnerability that we need to ignore because it was incorrectly applied to the Python Redis module.  This is a vulnerability with an older version of Redis itself, not the Python module.

## Security Considerations

Vulnerability: `Redis v7.0 was discovered to contain a memory leak via the component streamGetEdgeID.`

- This vulnerability applies to Redis itself and not the Python package, more info here: https://github.com/pypa/advisory-database/issues/207
