### PR TITLE
Change max tasks per celery worker to 500

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -166,7 +166,7 @@ class Config(object):
     current_minute = (datetime.now().minute + 1) % 60
 
     CELERY = {
-        "worker_max_tasks_per_child": 200,
+        "worker_max_tasks_per_child": 500,
         "broker_url": REDIS_URL,
         "broker_transport_options": {
             "visibility_timeout": 310,


### PR DESCRIPTION
## Description

During a load test we observed that memory usage looked pretty stable, but that we were seeing a lot of celery retries.  We think 200 max tasks per worker might be too low of a number and causing excessive churn so bump it up to 500.

## Security Considerations

N/A