### PR TITLE
increase db size from micro to small on staging

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -18,7 +18,7 @@ module "database" {
   cf_org_name   = local.cf_org_name
   cf_space_name = local.cf_space_name
   name          = "${local.app_name}-rds-${local.env}"
-  rds_plan_name = "micro-psql"
+  rds_plan_name = "small-psql"
 }
 
 module "redis-v70" {


### PR DESCRIPTION
## Description

Right now we are timing out when we try to read 25,000 notifications from the db in 30 seconds.   But if we want to scale and support more activity, we need to be able to do this.  Try increasing the rds instance size from micro to small in the staging environment.

## Security Considerations

N/A