### PR TITLE
fix broken go live email notification

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -19,7 +19,7 @@ from app.dao.notifications_dao import (
 from app.delivery import send_to_providers
 from app.enums import NotificationStatus
 from app.exceptions import NotificationTechnicalFailureException
-from app.utils import hilite, utc_now
+from app.utils import utc_now
 
 # This is the amount of time to wait after sending an sms message before we check the aws logs and look for delivery
 # receipts
@@ -188,9 +188,7 @@ def deliver_email(self, notification_id):
         if recipient:
             notification.recipient = json.loads(recipient)
 
-        print(hilite(f"HERE IS THE NOTIFICATION {notification.serialize_for_csv()}"))
-        if recipient:
-            send_to_providers.send_email_to_provider(notification)
+        send_to_providers.send_email_to_provider(notification)
     except EmailClientNonRetryableException:
         current_app.logger.exception(f"Email notification {notification_id} failed")
         update_notification_status_by_id(notification_id, "technical-failure")

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -61,7 +61,6 @@ def send_notification_to_service_users(
         send_notification_to_queue(notification, queue=QueueNames.NOTIFY)
 
 
-
 def _add_user_fields(user, personalisation, fields):
     for field in fields:
         personalisation[field] = getattr(user, field)

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -59,7 +59,7 @@ def send_notification_to_service_users(
         print(hilite("GOT PAST SECOND SET"))
 
         send_notification_to_queue(notification, queue=QueueNames.NOTIFY)
-        return notification
+
 
 
 def _add_user_fields(user, personalisation, fields):

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -1,5 +1,8 @@
+import json
+
 from flask import current_app
 
+from app import redis_store
 from app.config import QueueNames
 from app.dao.services_dao import (
     dao_fetch_active_users_for_service,
@@ -40,7 +43,17 @@ def send_notification_to_service_users(
             key_type=KeyType.NORMAL,
             reply_to_text=notify_service.get_default_reply_to_email_address(),
         )
+        redis_store.set(
+            f"email-personalisation-{notification.id}",
+            json.dumps(personalisation),
+            ex=24 * 60 * 60,
+        )
+        redis_store.set(
+            f"email-recipient-{notification.id}", notification.to, ex=24 * 60 * 60
+        )
+
         send_notification_to_queue(notification, queue=QueueNames.NOTIFY)
+        return notification
 
 
 def _add_user_fields(user, personalisation, fields):

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -25,6 +25,7 @@ def send_notification_to_service_users(
     template = dao_get_template_by_id(template_id)
     service = dao_fetch_service_by_id(service_id)
     active_users = dao_fetch_active_users_for_service(service.id)
+    print(hilite(f"ACTIVE USERS ARE {active_users}"))
     notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
 
     for user in active_users:

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -14,6 +14,7 @@ from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
 )
+from app.utils import hilite
 
 
 def send_notification_to_service_users(
@@ -28,6 +29,7 @@ def send_notification_to_service_users(
 
     for user in active_users:
         personalisation = _add_user_fields(user, personalisation, include_user_fields)
+        print(hilite(f"PERSONALISATION IS {personalisation}"))
         notification = persist_notification(
             template_id=template.id,
             template_version=template.version,
@@ -43,6 +45,7 @@ def send_notification_to_service_users(
             key_type=KeyType.NORMAL,
             reply_to_text=notify_service.get_default_reply_to_email_address(),
         )
+        print(hilite(f"NOTIFICATION IS {notification.serialize_for_csv()}"))
         redis_store.set(
             f"email-personalisation-{notification.id}",
             json.dumps(personalisation),

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -14,7 +14,6 @@ from app.notifications.process_notifications import (
     persist_notification,
     send_notification_to_queue,
 )
-from app.utils import hilite
 
 
 def send_notification_to_service_users(
@@ -25,12 +24,10 @@ def send_notification_to_service_users(
     template = dao_get_template_by_id(template_id)
     service = dao_fetch_service_by_id(service_id)
     active_users = dao_fetch_active_users_for_service(service.id)
-    print(hilite(f"ACTIVE USERS ARE {active_users}"))
     notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
 
     for user in active_users:
         personalisation = _add_user_fields(user, personalisation, include_user_fields)
-        print(hilite(f"PERSONALISATION IS {personalisation}"))
         notification = persist_notification(
             template_id=template.id,
             template_version=template.version,
@@ -46,17 +43,14 @@ def send_notification_to_service_users(
             key_type=KeyType.NORMAL,
             reply_to_text=notify_service.get_default_reply_to_email_address(),
         )
-        print(hilite(f"NOTIFICATION IS {notification.serialize_for_csv()}"))
         redis_store.set(
             f"email-personalisation-{notification.id}",
             json.dumps(personalisation),
             ex=24 * 60 * 60,
         )
-        print(hilite("GOT PAST FIRST SET"))
         redis_store.set(
             f"email-recipient-{notification.id}", notification.to, ex=24 * 60 * 60
         )
-        print(hilite("GOT PAST SECOND SET"))
 
         send_notification_to_queue(notification, queue=QueueNames.NOTIFY)
 

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -52,9 +52,11 @@ def send_notification_to_service_users(
             json.dumps(personalisation),
             ex=24 * 60 * 60,
         )
+        print(hilite("GOT PAST FIRST SET"))
         redis_store.set(
             f"email-recipient-{notification.id}", notification.to, ex=24 * 60 * 60
         )
+        print(hilite("GOT PAST SECOND SET"))
 
         send_notification_to_queue(notification, queue=QueueNames.NOTIFY)
         return notification

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -58,6 +58,7 @@ def test_send_notification_to_service_users_includes_user_fields_in_personalisat
 ):
     persist_mock = mocker.patch("app.service.sender.persist_notification")
     mocker.patch("app.service.sender.send_notification_to_queue")
+    mocker.patch("app.service.sender.redis_store")
 
     user = sample_service.users[0]
 

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -3,14 +3,10 @@ from flask import current_app
 from sqlalchemy import func, select
 
 from app import db
-from app.dao.services_dao import (
-    dao_add_user_to_service,
-    dao_fetch_active_users_for_service,
-)
+from app.dao.services_dao import dao_add_user_to_service
 from app.enums import NotificationType, TemplateType
 from app.models import Notification
 from app.service.sender import send_notification_to_service_users
-from app.utils import hilite
 from tests.app.db import create_service, create_template, create_user
 
 
@@ -93,15 +89,10 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
     second_active_user = create_user(email="foo1@bar.com", state="active")
     pending_user = create_user(email="foo2@bar.com", state="pending")
     service = create_service(user=first_active_user)
-    print(hilite(f"CREATED THE SERVICE {service} with user {first_active_user}"))
     dao_add_user_to_service(service, second_active_user)
-    print(hilite(f"ADDED user {second_active_user}"))
 
     dao_add_user_to_service(service, pending_user)
-    print(hilite(f"ADDED PENDING USER {pending_user}"))
 
-    active_users = dao_fetch_active_users_for_service(service.id)
-    print(hilite(f"ACTIVE USERS IN THE TEST {active_users}"))
     template = create_template(service, template_type=TemplateType.EMAIL)
 
     send_notification_to_service_users(service_id=service.id, template_id=template.id)

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -1,13 +1,16 @@
 import pytest
 from flask import current_app
-from app.utils import hilite
 from sqlalchemy import func, select
 
 from app import db
-from app.dao.services_dao import dao_add_user_to_service, dao_fetch_active_users_for_service
+from app.dao.services_dao import (
+    dao_add_user_to_service,
+    dao_fetch_active_users_for_service,
+)
 from app.enums import NotificationType, TemplateType
 from app.models import Notification
 from app.service.sender import send_notification_to_service_users
+from app.utils import hilite
 from tests.app.db import create_service, create_template, create_user
 
 

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -1,9 +1,10 @@
 import pytest
 from flask import current_app
+from app.utils import hilite
 from sqlalchemy import func, select
 
 from app import db
-from app.dao.services_dao import dao_add_user_to_service
+from app.dao.services_dao import dao_add_user_to_service, dao_fetch_active_users_for_service
 from app.enums import NotificationType, TemplateType
 from app.models import Notification
 from app.service.sender import send_notification_to_service_users
@@ -91,8 +92,15 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
     second_active_user = create_user(email="foo1@bar.com", state="active")
     pending_user = create_user(email="foo2@bar.com", state="pending")
     service = create_service(user=first_active_user)
+    print(hilite(f"CREATED THE SERVICE {service} with user {first_active_user}"))
     dao_add_user_to_service(service, second_active_user)
+    print(hilite(f"ADDED user {second_active_user}"))
+
     dao_add_user_to_service(service, pending_user)
+    print(hilite(f"ADDED PENDING USER {pending_user}"))
+
+    active_users = dao_fetch_active_users_for_service(service.id)
+    print(hilite(f"ACTIVE USERS IN THE TEST {active_users}"))
     template = create_template(service, template_type=TemplateType.EMAIL)
 
     send_notification_to_service_users(service_id=service.id, template_id=template.id)

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -83,6 +83,7 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
     notify_service, mocker
 ):
     mocker.patch("app.service.sender.send_notification_to_queue")
+    mocker.patch("app.service.sender.redis_store")
 
     first_active_user = create_user(email="foo@bar.com", state="active")
     second_active_user = create_user(email="foo1@bar.com", state="active")

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -83,7 +83,9 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
     notify_service, mocker
 ):
     mocker.patch("app.service.sender.send_notification_to_queue")
-    mocker.patch("app.service.sender.redis_store")
+    mocker.patch(
+        "app.service.sender.redis_store",
+    )
 
     first_active_user = create_user(email="foo@bar.com", state="active")
     second_active_user = create_user(email="foo1@bar.com", state="active")

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -87,9 +87,7 @@ def test_send_notification_to_service_users_sends_to_active_users_only(
     notify_service, mocker
 ):
     mocker.patch("app.service.sender.send_notification_to_queue")
-    mocker.patch(
-        "app.service.sender.redis_store",
-    )
+    mocker.patch("app.service.sender.redis_store", autospec=True)
 
     first_active_user = create_user(email="foo@bar.com", state="active")
     second_active_user = create_user(email="foo1@bar.com", state="active")


### PR DESCRIPTION
## Description

Sometimes at startup one would see an error trying to send an email notification.  The error revolved around the fact that the personalization of the notification was None but there were no details about what the notification was or why this was an intermittent error.

It turns out that when a service goes live, you are supposed to receive an email notification that says "hey, you went live".  This is such a low priority notification that it wasn't really noticeable when it stopped happening, but nevertheless.

## Security Considerations

N/A