### PR TITLE
fix notification insert retry logic

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -346,9 +346,14 @@ def save_api_email_or_sms(self, encrypted_notification):
             status=notification["status"],
             document_download_count=notification["document_download_count"],
         )
+        # Only get here if save to the db was successful (i.e. first time)
+        provider_task.apply_async([notification["id"]], queue=q)
+        current_app.logger.debug(
+            f"{notification['notification_type']} {notification['id']} has been persisted and sent to delivery queue."
+        )
 
     except IntegrityError:
-        current_app.logger.info(
+        current_app.logger.warning(
             f"{notification['notification_type']} {notification['id']} already exists."
         )
         # If we don't have the return statement here, we will fall through and end
@@ -362,10 +367,6 @@ def save_api_email_or_sms(self, encrypted_notification):
             current_app.logger.exception(
                 f"Max retry failed Failed to persist notification {notification['id']}",
             )
-    provider_task.apply_async([notification["id"]], queue=q)
-    current_app.logger.debug(
-        f"{notification['notification_type']} {notification['id']} has been persisted and sent to delivery queue."
-    )
 
 
 def handle_exception(task, notification, notification_id, exc):


### PR DESCRIPTION
## Description

There was flaw in the logic that inserts notifications into the db.  In the event of a duplicate insert, we were supposed to quit trying immediately.  However, because IntegrityError is a subclass of SQLAlchemyError we ended falling through the catch phase and activating the retry logic.   So we ended up getting 5 copies of the duplicate error in the logs, and because we hit the SQLAlchemyError the whole exception stack trace got printed, which resulted in millions of log lines when we ran a 25k send.

Fix the logic so we exit abruptly on a duplicate insert.  This short circuits the retry logic and results in only one warning level log line.   This, in combination with having each worker support 500 tasks instead of 200 tasks, should reduce the volume of logging from retries by over 90%.  Note that there is a separate category of log pollution for 'NoSuchKey' that is written up in a separate ticket and not directly related to this issue (although eliminating the retries may end up helping).

## Security Considerations

N/A