### PR TITLE
change create notification to only insert once

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -274,7 +274,7 @@ def save_email(
             "Email {} failed as restricted service".format(notification_id)
         )
         return
-
+    original_notification = get_notification(notification_id)
     try:
         saved_notification = persist_notification(
             template_id=notification["template"],
@@ -291,10 +291,11 @@ def save_email(
             notification_id=notification_id,
             reply_to_text=reply_to_text,
         )
-
-        provider_tasks.deliver_email.apply_async(
-            [str(saved_notification.id)], queue=QueueNames.SEND_EMAIL
-        )
+        # we only want to send once
+        if original_notification is None:
+            provider_tasks.deliver_email.apply_async(
+                [str(saved_notification.id)], queue=QueueNames.SEND_EMAIL
+            )
 
         current_app.logger.debug(
             "Email {} created at {}".format(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -73,7 +73,10 @@ def dao_create_notification(notification):
     notification.normalised_to = "1"
 
     # notify-api-1454 change to an upsert
-    db.session.merge(notification)
+    stmt = select(Notification).where(Notification.id == notification.id)
+    result = db.session.execute(stmt).scalar()
+    if result is None:
+        db.session.add(notification)
 
 
 def country_records_delivery(phone_prefix):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -72,7 +72,7 @@ def dao_create_notification(notification):
     notification.to = "1"
     notification.normalised_to = "1"
 
-    # notify-api-1454 change to an upsert
+    # notify-api-1454 insert only if it doesn't exist
     stmt = select(Notification).where(Notification.id == notification.id)
     result = db.session.execute(stmt).scalar()
     if result is None:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -71,7 +71,9 @@ def dao_create_notification(notification):
     # notify-api-742 remove phone numbers from db
     notification.to = "1"
     notification.normalised_to = "1"
-    db.session.add(notification)
+
+    # notify-api-1454 change to an upsert
+    db.session.merge(notification)
 
 
 def country_records_delivery(phone_prefix):

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -8,6 +8,7 @@ from app.config import QueueNames
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notifications_by_id,
+    get_notification_by_id,
 )
 from app.enums import KeyType, NotificationStatus, NotificationType
 from app.errors import BadRequestError
@@ -51,6 +52,10 @@ def check_placeholders(template_object):
             ", ".join(template_object.missing_data)
         )
         raise BadRequestError(fields=[{"template": message}], message=message)
+
+
+def get_notification(notification_id):
+    return get_notification_by_id(notification_id)
 
 
 def persist_notification(


### PR DESCRIPTION
## Description

We are getting hammered by duplicate insert/integrity errors.  Change the logic so notifications can only be inserted once.

NOTE:  I tried db.session.merge(notification) and it resulted in hundreds of test failures, unfortunately.  So I went with the clunky approach that doesn't break tests.

## Security Considerations

N/A