### PR TITLE
Bump production Redis plan to 5node-large

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -27,7 +27,7 @@ module "redis-v70" {
   cf_org_name     = local.cf_org_name
   cf_space_name   = local.cf_space_name
   name            = "${local.app_name}-redis-v70-${local.env}"
-  redis_plan_name = "redis-3node-large"
+  redis_plan_name = "redis-5node-large"
   json_params = jsonencode(
     {
       "engineVersion" : "7.0",


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset boosts our production Redis configuration to the 5node-large plan to give us a bit more wiggle room for heavy production workloads.  This should still keep us in the threshold of the second block of 10 nodes we are already signed up for as we currently have 12 nodes going across all environments at the moment.

## Security Considerations

* Boosting the amount of resources available for our backend services should help keep the application stable as we scale it.
