### PR TITLE
Revert Redis plan back

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -27,7 +27,7 @@ module "redis-v70" {
   cf_org_name     = local.cf_org_name
   cf_space_name   = local.cf_space_name
   name            = "${local.app_name}-redis-v70-${local.env}"
-  redis_plan_name = "redis-5node-large"
+  redis_plan_name = "redis-3node-large"
   json_params = jsonencode(
     {
       "engineVersion" : "7.0",


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

Changing the Redis plan in place is not supported - we would need to create a new cluster and then remove the old one.

## Security Considerations

* N/A with this change.
