### PR TITLE
add expire times for redis objects

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,7 @@ class TaskNames(object):
 
 class Config(object):
     NOTIFY_APP_NAME = "api"
-    DEFAULT_REDIS_EXPIRE_TIME = 8 * 24 * 60 * 60
+    DEFAULT_REDIS_EXPIRE_TIME = 4 * 24 * 60 * 60
     NOTIFY_ENVIRONMENT = getenv("NOTIFY_ENVIRONMENT", "development")
     # URL of admin app
     ADMIN_BASE_URL = getenv("ADMIN_BASE_URL", "http://localhost:6012")

--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,7 @@ class TaskNames(object):
 
 class Config(object):
     NOTIFY_APP_NAME = "api"
+    DEFAULT_REDIS_EXPIRE_TIME = 8 * 24 * 60 * 60
     NOTIFY_ENVIRONMENT = getenv("NOTIFY_ENVIRONMENT", "development")
     # URL of admin app
     ADMIN_BASE_URL = getenv("ADMIN_BASE_URL", "http://localhost:6012")

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import ANY
 
 import pytest
 from botocore.exceptions import ClientError
@@ -148,7 +149,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_sms_task
     deliver_sms(notification_id)
     app.delivery.send_to_providers.send_sms_to_provider.assert_not_called()
     app.celery.provider_tasks.deliver_sms.retry.assert_called_with(
-        queue="retry-tasks", countdown=0
+        queue="retry-tasks", countdown=0, expires=ANY
     )
 
 
@@ -208,7 +209,7 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(
     assert str(sample_notification.id) in str(e.value)
 
     provider_tasks.deliver_sms.retry.assert_called_with(
-        queue="retry-tasks", countdown=0
+        queue="retry-tasks", countdown=0, expires=ANY
     )
 
     assert sample_notification.status == NotificationStatus.TEMPORARY_FAILURE
@@ -240,7 +241,7 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_email_ta
     deliver_email(notification_id)
     app.delivery.send_to_providers.send_email_to_provider.assert_not_called()
     app.celery.provider_tasks.deliver_email.retry.assert_called_with(
-        queue="retry-tasks"
+        queue="retry-tasks", expires=ANY
     )
 
 
@@ -268,7 +269,9 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task
         deliver_email(sample_notification.id)
     assert str(sample_notification.id) in str(e.value)
 
-    provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks")
+    provider_tasks.deliver_email.retry.assert_called_with(
+        queue="retry-tasks", expires=ANY
+    )
     assert sample_notification.status == NotificationStatus.TECHNICAL_FAILURE
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -415,7 +415,7 @@ def test_check_for_missing_rows_in_completed_jobs_calls_save_email(
         ),
         {},
         queue="database-tasks",
-        expires=ANY
+        expires=ANY,
     )
 
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -415,6 +415,7 @@ def test_check_for_missing_rows_in_completed_jobs_calls_save_email(
         ),
         {},
         queue="database-tasks",
+        expires=ANY
     )
 
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -356,7 +356,7 @@ def test_process_row_sends_letter_task(
         ),
         {},
         queue=expected_queue,
-        expires=ANY
+        expires=ANY,
     )
 
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -356,6 +356,7 @@ def test_process_row_sends_letter_task(
         ),
         {},
         queue=expected_queue,
+        expires=ANY
     )
 
 


### PR DESCRIPTION
## Description

In doing some high volume testing, we discovered that things being placed in redis under the 'retry-tasks' and 'database-tasks' keys were never getting expired.  As a result redis ran out of memory and the whole app crashed and was unrecoverable until we did a purge of retry-tasks.

Set a default expiration time of 8 days.  8 days is probably unnecessarily long and can be revisited in the future, but will address the issue of redis filling up for the near future anyway.

## Security Considerations

N/A