### PR TITLE
change worker_max_tasks_per_child to 2000

### DIFF
--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -158,7 +158,7 @@ class AwsCloudwatchClient(Client):
                 message["delivery"].get("phoneCarrier", "Unknown Carrier"),
             )
 
-        if time_now > (created_at + timedelta(hours=3)):
+        if time_now > (created_at + timedelta(hours=73)):
             # see app/models.py Notification. This message corresponds to "permanent-failure",
             # but we are copy/pasting here to avoid circular imports.
             return "failure", "Unable to find carrier response."

--- a/app/config.py
+++ b/app/config.py
@@ -167,7 +167,7 @@ class Config(object):
     current_minute = (datetime.now().minute + 1) % 60
 
     CELERY = {
-        "worker_max_tasks_per_child": 500,
+        "worker_max_tasks_per_child": 2000,
         "broker_url": REDIS_URL,
         "broker_transport_options": {
             "visibility_timeout": 310,


### PR DESCRIPTION
## Description

We are still suffering from periodic celery retries with can cause IntegrityErrors and such.  Since we currently see no signs of resource leakage, increase worker_max_tasks_per_child from 500 to 2000, which should cut retries by 75%.

## Security Considerations

N/A