### PR TITLE
add message_id column to notifications

### DIFF
--- a/migrations/versions/0413_add_message_id.py
+++ b/migrations/versions/0413_add_message_id.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0413_add_message_id
+Revises: 412_remove_priority
+Create Date: 2023-12-11 11:35:22.873930
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0413_add_message_id"
+down_revision = "0412_remove_priority"
+
+
+def upgrade():
+    op.add_column("notifications", sa.Column("message_id", sa.Text))
+
+
+def downgrade():
+    op.drop_column("notifications", "message_id")

--- a/migrations/versions/0413_add_message_id.py
+++ b/migrations/versions/0413_add_message_id.py
@@ -15,7 +15,14 @@ down_revision = "0412_remove_priority"
 
 def upgrade():
     op.add_column("notifications", sa.Column("message_id", sa.Text))
+    op.create_index(
+        "ix_notifications_message_id",
+        "notifications",
+        ["message_id"],
+        unique=False,
+    )
 
 
 def downgrade():
+    op.drop_index("ix_notifications_message_id", table_name="notifications")
     op.drop_column("notifications", "message_id")


### PR DESCRIPTION
## Description

Our original implementation of checking delivery receipts sent each request for a delivery receipt to a celery task, which made its own call to boto3 logs filter_log_events.  While this was very pythonic and celery-friendly, as we scale it is going to be a bottleneck.  AWS throttles the call to filter_log_events every time it exceeds 5 times per second,  If we have two users doing big runs, that will essentially be all the time.

We are going to refactor this functionality, and start by saving the message_id to the notifications table in the database.  We will then have a scheduled task that makes one call to filter_log_events every five minutes, and processes ALL delivery receipts for all services at the same time, using message_ids, which will identify individual notifications.



## Security Considerations

N/A