### PR TITLE
fix census BOM error

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -402,7 +402,7 @@ def extract_phones(job):
     phone_index = 0
     for item in first_row:
         # Note: may contain a BOM and look like \ufeffphone number
-        if item.lower() in ["phone number", "\\ufeffphone number"]:
+        if item.lower() in ["phone number", "\\ufeffphone number", "phone number\n"]:
             break
         phone_index = phone_index + 1
 

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -402,7 +402,12 @@ def extract_phones(job):
     phone_index = 0
     for item in first_row:
         # Note: may contain a BOM and look like \ufeffphone number
-        if item.lower() in ["phone number", "\\ufeffphone number", "phone number\n"]:
+        if item.lower() in [
+            "phone number",
+            "\\ufeffphone number",
+            "\\ufeffphone number\n",
+            "phone number\n",
+        ]:
             break
         phone_index = phone_index + 1
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -222,11 +222,15 @@ def test_get_s3_file_makes_correct_call(notify_api, mocker):
         (
             # simulate file saved with utf8withbom
             "\\ufeffPHONE NUMBER\n",
+            "eee",
+            2,
             "5555555552",
         ),
         (
             # simulate file saved without utf8withbom
             "\\PHONE NUMBER\n",
+            "eee",
+            2,
             "5555555552",
         ),
     ],

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -219,6 +219,16 @@ def test_get_s3_file_makes_correct_call(notify_api, mocker):
             2,
             "5555555552",
         ),
+        (
+            # simulate file saved with utf8withbom
+            "\\ufeffPHONE NUMBER\n",
+            "5555555552",
+        ),
+        (
+            # simulate file saved without utf8withbom
+            "\\PHONE NUMBER\n",
+            "5555555552",
+        ),
     ],
 )
 def test_get_phone_number_from_s3(


### PR DESCRIPTION
## Description

Census uploaded a file which looked okay to visual inspection but was reported as corrupt.  It turned out there was a BOM at the start of the file. We thought we were handling it already but we ignored the case where phone number is the only column.


## Security Considerations

N/A