### PR TITLE
stop workers from propagating logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import logging as real_logging
 import os
 import secrets
 import string
@@ -36,6 +37,9 @@ class NotifyCelery(Celery):
 
         # Configure Celery app with options from the main app config.
         self.config_from_object(app.config["CELERY"])
+        self.conf.worker_hijack_root_logger = False
+        logger = real_logging.getLogger("celery")
+        logger.propagate = False
 
     def send_task(self, name, args=None, kwargs=None, **other_kwargs):
         other_kwargs["headers"] = other_kwargs.get("headers") or {}

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -70,10 +70,12 @@ def init_app(app):
     for logger_instance, handler in product(loggers, handlers):
         logger_instance.addHandler(handler)
         logger_instance.setLevel(loglevel)
+        logger_instance.propagate = False
     warning_loggers = [logging.getLogger("boto3"), logging.getLogger("s3transfer")]
     for logger_instance, handler in product(warning_loggers, handlers):
         logger_instance.addHandler(handler)
         logger_instance.setLevel(logging.WARNING)
+        logger_instance.propagate = False
 
     # Suppress specific loggers to prevent leaking sensitive info
     logging.getLogger("boto3").setLevel(logging.ERROR)


### PR DESCRIPTION
## Description

We found that the celery workers are writing to logs for themselves and then propagating the message again to the main log, resulting in many duplicate log entries.  Stop this propagation.

## Security Considerations

N/A