### PR TITLE
remove tasks from redis after they complete

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -168,6 +168,9 @@ class Config(object):
 
     CELERY = {
         "worker_max_tasks_per_child": 500,
+        "task_ignore_result": True,
+        "result_expires": 0,
+        "result_persistent": False,
         "broker_url": REDIS_URL,
         "broker_transport_options": {
             "visibility_timeout": 310,


### PR DESCRIPTION
## Description

To keep Redis from filling up, eject tasks as soon as they complete.

## Security Considerations

N/A