### PR TITLE
API-1466 - Fixing database IntegrityError failures

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -174,9 +174,7 @@ def check_for_missing_rows_in_completed_jobs():
         for row_to_process in missing_rows:
             row = recipient_csv[row_to_process.missing_row]
             current_app.logger.info(
-                "Processing missing row: {} for job: {}".format(
-                    row_to_process.missing_row, job.id
-                )
+                f"Processing missing row: {row_to_process.missing_row} for job: {job.id}"
             )
             process_row(row, template, job, job.service, sender_id=sender_id)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -39,9 +39,7 @@ def process_job(job_id, sender_id=None):
     start = utc_now()
     job = dao_get_job_by_id(job_id)
     current_app.logger.info(
-        "Starting process-job task for job id {} with status: {}".format(
-            job_id, job.job_status
-        )
+        f"Starting process-job task for job id {job_id} with status: {job.job_status}"
     )
 
     if job.job_status != JobStatus.PENDING:
@@ -57,7 +55,7 @@ def process_job(job_id, sender_id=None):
         job.job_status = JobStatus.CANCELLED
         dao_update_job(job)
         current_app.logger.warning(
-            "Job {} has been cancelled, service {} is inactive".format(
+            f"Job {job_id} has been cancelled, service {service.id} is inactive".format(
                 job_id, service.id
             )
         )
@@ -71,9 +69,7 @@ def process_job(job_id, sender_id=None):
     )
 
     current_app.logger.info(
-        "Starting job {} processing {} notifications".format(
-            job_id, job.notification_count
-        )
+        f"Starting job {job_id} processing {job.notification_count} notifications"
     )
 
     for row in recipient_csv.get_rows():
@@ -236,9 +232,10 @@ def save_sms(self, service_id, notification_id, encrypted_notification, sender_i
                 notification_id=notification_id,
                 reply_to_text=reply_to_text,
             )
-        except IntegrityError as e:
+        except IntegrityError:
             if notification_exists(notification_id):
                 saved_notification = get_notification(notification_id)
+
             else:
                 raise
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -23,6 +23,7 @@ from app.enums import JobStatus, KeyType, NotificationType
 from app.errors import TotalRequestsError
 from app.notifications.process_notifications import (
     get_notification,
+    notification_exists,
     persist_notification,
 )
 from app.notifications.validators import check_service_over_total_message_limit
@@ -218,22 +219,28 @@ def save_sms(self, service_id, notification_id, encrypted_notification, sender_i
             job = dao_get_job_by_id(job_id)
             created_by_id = job.created_by_id
 
-        saved_notification = persist_notification(
-            template_id=notification["template"],
-            template_version=notification["template_version"],
-            recipient=notification["to"],
-            service=service,
-            personalisation=notification.get("personalisation"),
-            notification_type=NotificationType.SMS,
-            api_key_id=None,
-            key_type=KeyType.NORMAL,
-            created_at=utc_now(),
-            created_by_id=created_by_id,
-            job_id=notification.get("job", None),
-            job_row_number=notification.get("row_number", None),
-            notification_id=notification_id,
-            reply_to_text=reply_to_text,
-        )
+        try:
+            saved_notification = persist_notification(
+                template_id=notification["template"],
+                template_version=notification["template_version"],
+                recipient=notification["to"],
+                service=service,
+                personalisation=notification.get("personalisation"),
+                notification_type=NotificationType.SMS,
+                api_key_id=None,
+                key_type=KeyType.NORMAL,
+                created_at=utc_now(),
+                created_by_id=created_by_id,
+                job_id=notification.get("job", None),
+                job_row_number=notification.get("row_number", None),
+                notification_id=notification_id,
+                reply_to_text=reply_to_text,
+            )
+        except IntegrityError as e:
+            if notification_exists(notification_id):
+                saved_notification = get_notification(notification_id)
+            else:
+                raise
 
         # Kick off sns process in provider_tasks.py
         sn = saved_notification
@@ -247,11 +254,8 @@ def save_sms(self, service_id, notification_id, encrypted_notification, sender_i
         )
 
         current_app.logger.debug(
-            "SMS {} created at {} for job {}".format(
-                saved_notification.id,
-                saved_notification.created_at,
-                notification.get("job", None),
-            )
+            f"SMS {saved_notification.id} created at {saved_notification.created_at} "
+            f"for job {notification.get('job', None)}"
         )
 
     except SQLAlchemyError as e:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -65,6 +65,12 @@ def dao_get_last_date_template_was_used(template_id, service_id):
     return last_date
 
 
+def dao_notification_exists(notification_id) -> bool:
+    stmt = select(Notification).where(Notification.id == notification_id)
+    result = db.session.execute(stmt).scalar()
+    return result is not None
+
+
 @autocommit
 def dao_create_notification(notification):
     if not notification.id:
@@ -86,9 +92,7 @@ def dao_create_notification(notification):
     notification.normalised_to = "1"
 
     # notify-api-1454 insert only if it doesn't exist
-    stmt = select(Notification).where(Notification.id == notification.id)
-    result = db.session.execute(stmt).scalar()
-    if result is None:
+    if not dao_notification_exists(notification.id):
         db.session.add(notification)
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -8,6 +8,7 @@ from app.config import QueueNames
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notifications_by_id,
+    dao_notification_exists,
     get_notification_by_id,
 )
 from app.enums import KeyType, NotificationStatus, NotificationType
@@ -151,6 +152,10 @@ def persist_notification(
             f"{notification_type} {notification_id} created at {notification_created_at}"
         )
     return notification
+
+
+def notification_exists(notification_id):
+    return dao_notification_exists(notification_id)
 
 
 def send_notification_to_queue_detached(


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This is an effort to fix the integrity error failures we are seeing. If this situation is encountered, it checks to see if the record already exists in the DB. If it does, instead of writing it and then getting the updated notification entry from the DB, it just loads the record from the DB and then continues on.

## Security Considerations

This is an effort to reduce the load on the celery tasks, and prevent a situation that would always cause a failure from "failing", because it can be continued. A more stable app is a more secure app.