### PR TITLE
Evaluate Batch Updates versus Bulk Updates

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -777,5 +777,6 @@ def dao_update_delivery_receipts(receipts, delivered):
     db.session.commit()
     elapsed_time = (time() * 1000) - start_time_millis
     current_app.logger.info(
-        f"#loadtestperformance batch update query time: {elapsed_time} ms"
+        f"#loadtestperformance batch update query time: \
+        updated {len(receipts)} notification in {elapsed_time} ms"
     )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from time import time
 
 from flask import current_app
 from sqlalchemy import (
@@ -727,6 +728,7 @@ def get_service_ids_with_notifications_on_date(notification_type, date):
 
 
 def dao_update_delivery_receipts(receipts, delivered):
+    start_time_millis = time() * 1000
     new_receipts = []
     for r in receipts:
         if isinstance(r, str):
@@ -773,3 +775,7 @@ def dao_update_delivery_receipts(receipts, delivered):
     )
     db.session.execute(stmt)
     db.session.commit()
+    elapsed_time = (time() * 1000) - start_time_millis
+    current_app.logger.info(
+        f"#loadtestperformance batch update query time: {elapsed_time} ms"
+    )


### PR DESCRIPTION
## Description

In order to do bulk updates we need the primary key for the notification table (notification.id), which we currently do not have.

Right now we are doing batch updates, which seem to work great.  But the question is how much can they scale.  If they can't scale, we have to switch to bulk updates which requires running a query to fetch all the notification_ids, or storing all the notification_ids in redis.

Add a debug statement to see the elapsed time of each batch update.  Currently we are doing batch updates of 1000.  If the time for the query is 200 ms, we can process 2500 records or so per second, which is 150k records a minute, which is nuts because right now we are doing far less than 1000 records a minute.  Conversely, if the time for the query is 2 minutes we need to start switching to bulk updates immediately.

Seeing how long the 1000 record batches take gives us a feel for how worthwhile it would be to switch to bulk updates.  It will also provide us data if we want to try batch sides of 2000, 5000, 10000 etc.


## Security Considerations

N/A