### PR TITLE
the way we set the sender phone number is very questionable

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -158,7 +158,7 @@ def _get_verify_code(notification):
         recipient = recipient.decode("utf-8")
     return recipient
 
-
+# PUT THE FIX HERE???????
 def get_sender_numbers(notification):
     possible_senders = dao_get_sms_senders_by_service_id(notification.service_id)
     sender_numbers = []

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -158,7 +158,7 @@ def _get_verify_code(notification):
         recipient = recipient.decode("utf-8")
     return recipient
 
-# PUT THE FIX HERE???????
+
 def get_sender_numbers(notification):
     possible_senders = dao_get_sms_senders_by_service_id(notification.service_id)
     sender_numbers = []

--- a/app/models.py
+++ b/app/models.py
@@ -577,7 +577,16 @@ class Service(db.Model, Versioned):
             return self.inbound_number.number
 
     def get_default_sms_sender(self):
-        default_sms_sender = [x for x in self.service_sms_senders if x.is_default]
+        # notify-api-1513 let's try a minimalistic fix
+        # to see if we can get the right numbers back
+        default_sms_sender = [
+            x
+            for x in self.service_sms_senders
+            if x.is_default and x.service_id == self.id
+        ]
+        current_app.logger.info(
+            f"#notify-api-1513 senders for service {self.name} are {self.service_sms_senders}"
+        )
         return default_sms_sender[0].sms_sender
 
     def get_default_reply_to_email_address(self):


### PR DESCRIPTION

## Description

We previously saw a bug where we were trying to set created_at to "now" in the Job class and while that worked most of the time, some time it set the time to 72 hours in the past, resulting in data missing from the seven day reports.

We have an issue for some time where messages sometimes go out with the wrong sender phone number.   It has been very mysterious and hard to debug.   The data in the db looks correct.  We can look in the UI and see the numbers assigned to every service, so what could be going on?

Well, if you look at what this code was trying to do, it seems like the original form was just pulling all sender phone numbers in the service_sms_sender table and relying on some kind of sqlalchemy magic to limit the result set to the numbers associated with the service in question.

Let's try modifying this to "only pull the numbers that really are associated with the service, where the id matches, and let's have some debug output so we can confirm it is now working properly."

NOTE: with regard to the debug, our scrubber will convert the phone numbers in the logs to 1XXXXXXXXXX but this should be fine, because what we are looking for is not the specific phone numbers but how many numbers are actually in the list.  Typically, a service has one 800 number and then our default notify.gov number.  There shouldn't be 10 or 20 numbers there.

If this doesn't work, it may be necessary to explicitly write a query, but that will involve working around some circular import issues.  We can't dao calls inside models, for example.

## Security Considerations

N/A