### PR TITLE
Change delivery receipts tasks time to help UI lag

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -256,7 +256,7 @@ def process_delivery_receipts(self):
 
         cloudwatch = AwsCloudwatchClient()
         cloudwatch.init_app(current_app)
-        start_time = aware_utcnow() - timedelta(minutes=10)
+        start_time = aware_utcnow() - timedelta(minutes=3)
         end_time = aware_utcnow()
         delivered_receipts, failed_receipts = cloudwatch.check_delivery_receipts(
             start_time, end_time

--- a/app/config.py
+++ b/app/config.py
@@ -200,7 +200,7 @@ class Config(object):
             },
             "process-delivery-receipts": {
                 "task": "process-delivery-receipts",
-                "schedule": timedelta(minutes=8),
+                "schedule": timedelta(minutes=2),
                 "options": {"queue": QueueNames.PERIODIC},
             },
             "expire-or-delete-invitations": {


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This change lowers the task schedule time in `config.py:process-delivery-receipts` from 8 min to 2 min. It will also lower the time chunk size in `scheduled_tasks.py:process_delivery_reciepts()` from 10 min to 3 min. I tried this out locally with a few load test of about 500 each send. There was little lag on the UI for messages stuck in the pending state. This could be tested in staging as well with a full load test.
