### PR TITLE
Update daily_check GitHub Action

### DIFF
--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run scan
         run: bandit -r app/ -f txt -o /tmp/bandit-output.txt --confidence-level medium
       - name: Upload bandit artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bandit-report
           path: /tmp/bandit-output.txt


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset updates the reference of the upload_artifacts action from GitHub to be v4 instead of v3. v3 is being deprecated at the end of January 2025.

Thank you @rahearn for the catch on this!

## Security Considerations

* Keeping our dependencies up-to-date makes sure our application stays secure and functional.
