### PR TITLE
set prefetch multiplier to 2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
       - type: worker
         instances: ((worker_instances))
         memory: ((worker_memory))
-        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=threads --concurrency=10
+        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=threads --concurrency=15 --prefetch-multiplier=2
       - type: scheduler
         instances: 1
         memory: ((scheduler_memory))

--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
       - type: worker
         instances: ((worker_instances))
         memory: ((worker_memory))
-        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=threads --concurrency=15 --prefetch-multiplier=2
+        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=threads --concurrency=10 --prefetch-multiplier=2
       - type: scheduler
         instances: 1
         memory: ((scheduler_memory))


### PR DESCRIPTION
## Description

Our celery configuration was mostly default settings.  Default settings are for apps that are cpu-bound, but ours is io-bound.   For the case of the --prefetch_multiplier, this is talking about how many tasks each thread can hold onto while it is doing its thing.  The more tasks that a thread holds onto, the more memory is used and more latency is potentially increased.  The optimal value for io-bounds is supposed to be 1 or 2, whereas the default is 4.


## Security Considerations

N/A

