### PR TITLE
Invite expiration fix

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -101,13 +101,7 @@ def dao_create_notification(notification):
         # Ensure the created at value is set and debug.
         if notification.notification_type == "email":
             orig_time = notification.created_at
-
             now_time = utc_now()
-            print(
-                hilite(
-                    f"original time: {orig_time} - {type(orig_time)} \n now time: {now_time} - {type(now_time)}"
-                )
-            )
             try:
                 diff_time = now_time - orig_time
             except TypeError:

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -30,7 +30,6 @@ from app.models import FactNotificationStatus, Notification, NotificationHistory
 from app.utils import (
     escape_special_characters,
     get_midnight_in_utc,
-    hilite,
     midnight_n_days_ago,
     utc_now,
 )

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -103,8 +103,19 @@ def dao_create_notification(notification):
             orig_time = notification.created_at
 
             now_time = utc_now()
-            print(hilite(f"original time: {orig_time} - {type(orig_time)} \n now time: {now_time} - {type(now_time)}"))
-            diff_time = now_time - datetime.strptime(orig_time, "%Y-%m-%D-%H-%M-%S")
+            print(
+                hilite(
+                    f"original time: {orig_time} - {type(orig_time)} \n now time: {now_time} - {type(now_time)}"
+                )
+            )
+            try:
+                diff_time = now_time - orig_time
+            except TypeError:
+                try:
+                    orig_time = datetime.strptime(orig_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+                except ValueError:
+                    orig_time = datetime.strptime(orig_time, "%Y-%m-%d")
+                diff_time = now_time - orig_time
             current_app.logger.error(
                 f"dao_create_notification orig created at: {orig_time} and now created at: {now_time}"
             )

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -25,7 +25,7 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.schemas import invited_user_schema
-from app.utils import hilite, utc_now
+from app.utils import utc_now
 from notifications_utils.url_safe_token import check_token, generate_token
 
 service_invite = Blueprint("service_invite", __name__)

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -25,7 +25,7 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.schemas import invited_user_schema
-from app.utils import utc_now
+from app.utils import hilite, utc_now
 from notifications_utils.url_safe_token import check_token, generate_token
 
 service_invite = Blueprint("service_invite", __name__)
@@ -67,7 +67,7 @@ def _create_service_invite(invited_user, nonce, state):
         "service_name": invited_user.service.name,
         "url": url,
     }
-
+    created_at = utc_now()
     saved_notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
@@ -78,6 +78,10 @@ def _create_service_invite(invited_user, nonce, state):
         api_key_id=None,
         key_type=KeyType.NORMAL,
         reply_to_text=invited_user.from_user.email_address,
+        created_at=created_at,
+    )
+    print(
+        hilite(f"saved notification created at time: {saved_notification.created_at}")
     )
     saved_notification.personalisation = personalisation
     redis_store.set(

--- a/app/service_invite/rest.py
+++ b/app/service_invite/rest.py
@@ -80,9 +80,6 @@ def _create_service_invite(invited_user, nonce, state):
         reply_to_text=invited_user.from_user.email_address,
         created_at=created_at,
     )
-    print(
-        hilite(f"saved notification created at time: {saved_notification.created_at}")
-    )
     saved_notification.personalisation = personalisation
     redis_store.set(
         f"email-personalisation-{saved_notification.id}",

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -103,7 +103,6 @@ def test_create_nightly_notification_status_triggers_relevant_tasks(
     mock_celery = mocker.patch(
         "app.celery.reporting_tasks.create_nightly_notification_status_for_service_and_day"
     ).apply_async
-
     for notification_type in NotificationType:
         template = create_template(sample_service, template_type=notification_type)
         create_notification(template=template, created_at=notification_date)


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

There have been instances where SQLAlchemy does some funky magic and sets the created_at times prior. We think this could be the issue with invites expiring mysteriously. The invite path leads through here so we add some debugging logic and update the created_at stamp if necessary.

Added some error handling because persist notification is called in quite a bit of different paths, so the created_at value is passed through in different forms. This fixed the issues I was having with tests being broken.

*During local testing, I have not been able to reproduce an invite expiring. Invites didn't expire on staging either.
