### PR TITLE
Make a command to see a service's sms sender phone numbers

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -846,6 +846,19 @@ def create_new_service(name, message_limit, restricted, email_from, created_by_i
         db.session.rollback()
 
 
+@notify_command(name="get-service-sender-phones")
+@click.option("-s", "--service_id", required=True, prompt=True)
+def get_service_sender_phones(service_id):
+    sender_phone_numbers = """
+            select sms_sender, is_default
+            from service_sms_senders
+            where service_id = :service_id
+        """
+    rows = db.session.execute(text(sender_phone_numbers), {"service_id": service_id})
+    for row in rows:
+        print(row)
+
+
 @notify_command(name="promote-user-to-platform-admin")
 @click.option("-u", "--user-email-address", required=True, prompt=True)
 def promote_user_to_platform_admin(user_email_address):


### PR DESCRIPTION
## Description

As we continue to investigate the 'wrong sender phone number' issue, add a command so we can inspect the values in the service_sms_senders table in the database.



## Security Considerations

- The numbers being retrieved are public numbers, as they are the ones that the messages come from.
- This command can only be run on machines by folks who have access to the information (or locally for development purposes, with test data), and/or in the environment in which the app itself runs.