### PR TITLE
Update Terraform config and revert staging deploy change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Check for changes to Terraform
       id: changed-terraform-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@v44
       with:
         files: |
           terraform/staging/**
@@ -84,7 +84,7 @@ jobs:
 
     - name: Check for changes to templates.json
       id: changed-templates
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@v44
       with:
         files: |
           app/config_files/templates.json

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -49,8 +49,7 @@ module "egress-space" {
   cf_org_name              = local.cf_org_name
   cf_restricted_space_name = local.cf_space_name
   deployers = [
-    var.cf_user,
-    "steven.reilly@gsa.gov"
+    var.cf_user
   ]
 }
 

--- a/terraform/sandbox/main.tf
+++ b/terraform/sandbox/main.tf
@@ -49,9 +49,7 @@ module "egress-space" {
   cf_org_name              = local.cf_org_name
   cf_restricted_space_name = local.cf_space_name
   deployers = [
-    var.cf_user,
-    "steven.reilly@gsa.gov",
-    "carlo.costino@gsa.gov"
+    var.cf_user
   ]
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -49,9 +49,7 @@ module "egress-space" {
   cf_org_name              = local.cf_org_name
   cf_restricted_space_name = local.cf_space_name
   deployers = [
-    var.cf_user,
-    "steven.reilly@gsa.gov",
-    "carlo.costino@gsa.gov"
+    var.cf_user
   ]
 }
 


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset updates the Terraform user configuration in several environments to factor in team member changes, and reverts the previous change to the staging deploy to see if there was an issue with the last update which is preventing the workflow from running now.

## Security Considerations

* We need to keep our configurations up-to-date in light of team changes.
