### PR TITLE
enable dependabot auto-merge magic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    labels:
+      - "dependabot" # Custom label to identify Dependabot PRs

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+# TODO
+# repo->Settings->Pull Requests->Check "Allow auto-merge"
+# Settings-Branches->Add/Edit branch protection rule for main:
+    # Check "Require status checks to pass before merging" and select build workflow (CI pipelilne name like 'build') to make sure PR only merges when it passes
+
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+  permissions:
+    pull-requests: write # To approve PRs
+    contents: write # to merge PRs
+
+  jobs:
+    auto-merge:
+      runs-on: ubuntu-latest
+      if: github.actor == 'dependabot[bot]' # Only dependabot PRs
+      steps:
+        - name: Checkout repo
+          users: actions/checkout@v4
+
+        - name: Fetch Dependabot metadata
+          id: metadata
+          uses: dependabot/fetch-metadata@v2
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Approve minor updates
+          if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          run: |
+            gh pr review "$PR_URL" --approve -b "Auto-approved minor update"
+          env:
+            PR_URL: ${{ github.event.pull_request.html_url }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Enable auto-merge for minor updates
+          if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          run: |
+            gh pr merge --auto --squash "$PR_URL"
+          env:
+            PR_URL: ${{ github.event.pull_request.html_url }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,18 +27,19 @@ on:
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Approve minor updates
-          if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
-          run: |
-            gh pr review "$PR_URL" --approve -b "Auto-approved minor update"
-          env:
-            PR_URL: ${{ github.event.pull_request.html_url }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # - name: Approve minor updates
+        #   if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        #   run: |
+        #     gh pr review "$PR_URL" --approve -b "Auto-approved minor update"
+        #   env:
+        #     PR_URL: ${{ github.event.pull_request.html_url }}
+        #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+        # use admin to bypass the need for approval, human PRs still need two approvals
         - name: Enable auto-merge for minor updates
           if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
           run: |
-            gh pr merge --auto --squash "$PR_URL"
+            gh pr merge --squash --admin "$PR_URL"
           env:
             PR_URL: ${{ github.event.pull_request.html_url }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

We want to allow dependabot to merge automatically for minor version updates that have PRs that pass all our tests.   In order for this to work, in addition to this code change, we have to make two Settings changes in GitHub:

1. General->Pull Requests-> allow auto-merge


Originally I was going to have the auto-merge script approve the review, but since human PRs require 2 approvals and its not possible to account for that in the Settings, I have changed the script to use the --admin flag, which should be able to merge the script with no reviews.  The 'review' will be the fact that the build passed (branches still have this protection in place).
     
TODO:

When this is merged, the next dependabot update that comes around should theoretically get auto merged.   Wouldn't that be nice if it worked the first time.


## Security Considerations

N/A