### PR TITLE
do a manifest.yml push to load new env variables

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -33,4 +33,6 @@ jobs:
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
           cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}-egress
-          command: "cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}"
+          command: |
+            cf push notify-${{matrix.app}}-${{inputs.environment}} -f manifest.yml --no-start
+            cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}


### PR DESCRIPTION
## Description

The restage command was not picking up changes to environment variables.  Explicitly push the manifest file to reload the environment variables before doing the restage.

## Security Considerations

N/A
