### PR TITLE
revert to using cf push

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -25,18 +25,9 @@ jobs:
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
           cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}
-          cf_command: >-
-            push -f manifest.yml
-            --vars-file deploy-config/${{inputs.environment}}.yml
-            --var DANGEROUS_SALT="$DANGEROUS_SALT"
-            --var SECRET_KEY="$SECRET_KEY"
-            --var ADMIN_CLIENT_SECRET="$ADMIN_CLIENT_SECRET"
-            --var NEW_RELIC_LICENSE_KEY="$NEW_RELIC_LICENSE_KEY"
-            --var NOTIFY_E2E_TEST_EMAIL="$NOTIFY_E2E_TEST_EMAIL"
-            --var NOTIFY_E2E_TEST_PASSWORD="$NOTIFY_E2E_TEST_PASSWORD"
-            --var LOGIN_DOT_GOV_REGISTRATION_URL="$LOGIN_DOT_GOV_REGISTRATION_URL"
-            --strategy rolling
-          command: "cf restage --strategy rolling notify-${{matrix.app}}-${{inputs.environment}}"
+          command: |
+            cf push notify-${{matrix.app}}-${{inputs.environment}} -f deploy-config/${{inputs.environment}}.yml --no-start
+            cf restage --strategy rolling notify-${{matrix.app}}-${{inputs.environment}}
       - name: Restage ${{matrix.app}} egress
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -44,6 +35,4 @@ jobs:
           cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
           cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}-egress
-
-          command: |
-            cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}
+          command: "cf restage --strategy rolling egress-proxy-notify-${{matrix.app}}-${{inputs.environment}}"


### PR DESCRIPTION
## Description

The previous approach didn't work.  Do `cf push` with the app name (ie notify-api-staging) and specify the manifest file as what is in the deploy-config folder (for example, deploy-config/staging.yml).


## Security Considerations

N/A