### PR TITLE
Use cf set-env to update environment variables on a restage

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         app: ["api", "admin"]
     steps:
-      - name: Update env variables ${{matrix.app}}
+      - name: Update env variables api
         uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
@@ -26,12 +26,29 @@ jobs:
           cf_org: gsa-tts-benefits-studio
           cf_space: notify-${{ inputs.environment }}
           command: |
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} DANGEROUS_SALT "${{secrets.DANGEROUS_SALT}}"
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} ADMIN_CLIENT_SECRET "${{secrets.ADMIN_CLIENT_SECRET}}"
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} SECRET_KEY "${{secrets.SECRET_KEY}}"
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} LOGIN_PEM "${{secrets.LOGIN_PEM}}"
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} NOTIFY_E2E_TEST_EMAIL "${{secrets.NOTIFY_E2E_TEST_EMAIL}}"
-            cf set-env notify-${{matrix.app}}-${{inputs.environment}} NOTIFY_E2E_TEST_PASSWORD "${{secrets.NOTIFY_E2E_TEST_PASSWORD}}"
+            cf set-env notify-api-${{inputs.environment}} DANGEROUS_SALT "${{secrets.DANGEROUS_SALT}}"
+            cf set-env notify-api-${{inputs.environment}} ADMIN_CLIENT_SECRET "${{secrets.ADMIN_CLIENT_SECRET}}"
+            cf set-env notify-api-${{inputs.environment}} SECRET_KEY "${{secrets.SECRET_KEY}}"
+            cf set-env notify-api-${{inputs.environment}} LOGIN_PEM "${{secrets.LOGIN_PEM}}"
+            cf set-env notify-api-${{inputs.environment}} NOTIFY_E2E_TEST_EMAIL "${{secrets.NOTIFY_E2E_TEST_EMAIL}}"
+            cf set-env notify-api-${{inputs.environment}} NOTIFY_E2E_TEST_PASSWORD "${{secrets.NOTIFY_E2E_TEST_PASSWORD}}"
+
+      - name: Update env variables admin
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CLOUDGOV_USERNAME }}
+          cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+          cf_org: gsa-tts-benefits-studio
+          cf_space: notify-${{ inputs.environment }}
+          command: |
+            cf set-env notify-admin-${{inputs.environment}} DANGEROUS_SALT "${{secrets.DANGEROUS_SALT}}"
+            cf set-env notify-admin-${{inputs.environment}} ADMIN_CLIENT_SECRET "${{secrets.ADMIN_CLIENT_SECRET}}"
+            cf set-env notify-admin-${{inputs.environment}} SECRET_KEY "${{secrets.SECRET_KEY}}"
+            cf set-env notify-admin-${{inputs.environment}} LOGIN_PEM "${{secrets.LOGIN_PEM}}"
+            cf set-env notify-admin-${{inputs.environment}} NOTIFY_E2E_TEST_EMAIL "${{secrets.NOTIFY_E2E_TEST_EMAIL}}"
+            cf set-env notify-admin-${{inputs.environment}} NOTIFY_E2E_TEST_PASSWORD "${{secrets.NOTIFY_E2E_TEST_PASSWORD}}"
+            cf set-env notify-api-${{inputs.environment}} E2E_BUCKET_NAME "${{secrets.E2E_BUCKET_NAME}}"
+
       - name: Restage ${{matrix.app}}
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -27,6 +27,11 @@ jobs:
           cf_space: notify-${{ inputs.environment }}
           command: |
             cf set-env notify-${{matrix.app}}-${{inputs.environment}} DANGEROUS_SALT "${{secrets.DANGEROUS_SALT}}"
+            cf set-env notify-${{matrix.app}}-${{inputs.environment}} ADMIN_CLIENT_SECRET "${{secrets.ADMIN_CLIENT_SECRET}}"
+            cf set-env notify-${{matrix.app}}-${{inputs.environment}} SECRET_KEY "${{secrets.SECRET_KEY}}"
+            cf set-env notify-${{matrix.app}}-${{inputs.environment}} LOGIN_PEM "${{secrets.LOGIN_PEM}}"
+            cf set-env notify-${{matrix.app}}-${{inputs.environment}} NOTIFY_E2E_TEST_EMAIL "${{secrets.NOTIFY_E2E_TEST_EMAIL}}"
+            cf set-env notify-${{matrix.app}}-${{inputs.environment}} NOTIFY_E2E_TEST_PASSWORD "${{secrets.NOTIFY_E2E_TEST_PASSWORD}}"
       - name: Restage ${{matrix.app}}
         uses: cloud-gov/cg-cli-tools@main
         with:


### PR DESCRIPTION
## Description

The restage action never pulled new environment variables, that is not part of what restage does in the Cloud Foundry system.  We lived with this for two years, and when we wanted to updated environment variables we would just do a deploy.   Ultimately, this was a hassle.

To fix, we looked at `cf push` with the manifest.yml file, but for some reason the file could not be found in the cloud foundry space.  Therefore, we switched to `cf set-env` and just update the handful of environment variables that we have.

## Security Considerations

N/A