### PR TITLE
Fixing an error in the recent migration for the e2e test user changes.

### DIFF
--- a/migrations/versions/0416_readd_e2e_test_user.py
+++ b/migrations/versions/0416_readd_e2e_test_user.py
@@ -44,8 +44,8 @@ def upgrade():
     conn = op.get_bind()
 
     # delete the old user because
-    delete_sql = """
-        delete from users where email_address='e2e-test-notify-user@fake.gov'
+    delete_sql = f"""
+        delete from users where email_address='{email_address}'
         """
 
     insert_sql = """


### PR DESCRIPTION
<!--
Not sure what you should include or write in a pull request?  Please read the
[pull request documentation in our docs!](https://github.com/GSA/notifications-api/blob/main/docs/all.md#pull-requests)
-->

*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

The migration for 0416 was incorrect, and would not remove the old e2e test user unless that user had the correct email address. This fixes that.

## Security Considerations

* Can't think of any. This just makes the migration work.