### PR TITLE
fix invites

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -186,7 +186,15 @@ def send_email_to_provider(notification):
     personalisation = redis_store.get(f"email-personalisation-{notification.id}")
     if personalisation:
         personalisation = personalisation.decode("utf-8")
-        notification.personalisation = json.loads(personalisation)
+        p = json.loads(personalisation)
+        if os.get("NOTIFY_ENVIRONMENT") == "staging":
+            current_app.logger.info(f"Invite personalization before {p}")
+        p = p.replace("%5B", "")
+        p = p.replace("%5D", "")
+        if os.get("NOTIFY_ENVIRONMENT") == "staging":
+            current_app.logger.info(f"Invite personalization after {p}")
+
+        notification.personalisation = p
 
     service = SerialisedService.from_id(notification.service_id)
     if not service.active:

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -187,11 +187,11 @@ def send_email_to_provider(notification):
     if personalisation:
         personalisation = personalisation.decode("utf-8")
         p = json.loads(personalisation)
-        if os.get("NOTIFY_ENVIRONMENT") == "staging":
+        if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization before {p}")
         p = p.replace("%5B", "")
         p = p.replace("%5D", "")
-        if os.get("NOTIFY_ENVIRONMENT") == "staging":
+        if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization after {p}")
 
         notification.personalisation = p

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -186,14 +186,14 @@ def send_email_to_provider(notification):
     personalisation = redis_store.get(f"email-personalisation-{notification.id}")
     if personalisation:
         personalisation = personalisation.decode("utf-8")
-        p = json.loads(personalisation)
+
         if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization before {p}")
         p = p.replace("%5B", "")
         p = p.replace("%5D", "")
         if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization after {p}")
-
+        p = json.loads(personalisation)
         notification.personalisation = p
 
     service = SerialisedService.from_id(notification.service_id)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -185,7 +185,7 @@ def send_email_to_provider(notification):
     recipient = recipient.decode("utf-8")
     personalisation = redis_store.get(f"email-personalisation-{notification.id}")
     if personalisation:
-        personalisation = personalisation.decode("utf-8")
+        p = personalisation.decode("utf-8")
 
         if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization before {p}")
@@ -193,7 +193,7 @@ def send_email_to_provider(notification):
         p = p.replace("%5D", "")
         if os.getenv("NOTIFY_ENVIRONMENT") == "staging":
             current_app.logger.info(f"Invite personalization after {p}")
-        p = json.loads(personalisation)
+        p = json.loads(p)
         notification.personalisation = p
 
     service = SerialisedService.from_id(notification.service_id)


### PR DESCRIPTION
## Description

Some regression took place where escaped parentheses (%5B, %5D) are being placed around the redirect_uri, resulting in login.gov claiming it is invalid.   For now, strip them right before we send the email.   

## Security Considerations

N/A