### PR TITLE
Update Makefile to handle pre-existing git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
 APP_VERSION_FILE = app/version.py
 
 GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
-GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || echo "")
+GIT_HOOKS_PATH ?= $(shell git config --global core.hooksPath || echo "")
 
 ## DEVELOPMENT
 
@@ -18,7 +19,9 @@ bootstrap: ## Set up everything to run the app
 	poetry self add poetry-dotenv-plugin
 	poetry lock --no-update
 	poetry install --sync --no-root
+	git config --global --unset-all core.hooksPath
 	poetry run pre-commit install
+	git config --global core.hookspath "${GIT_HOOKS_PATH}"
 	createdb notification_api || true
 	createdb test_notification_api || true
 	(poetry run flask db upgrade) || true

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,17 @@ bootstrap: ## Set up everything to run the app
 	poetry self add poetry-dotenv-plugin
 	poetry lock --no-update
 	poetry install --sync --no-root
+	poetry run pre-commit install
+	createdb notification_api || true
+	createdb test_notification_api || true
+	(poetry run flask db upgrade) || true
+
+.PHONY: bootstrap-with-git-hooks
+bootstrap-with-git-hooks:  ## Sets everything up and accounts for pre-existing git hooks
+	make generate-version-file
+	poetry self add poetry-dotenv-plugin
+	poetry lock --no-update
+	poetry install --sync --no-root
 	git config --global --unset-all core.hooksPath
 	poetry run pre-commit install
 	git config --global core.hookspath "${GIT_HOOKS_PATH}"


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds a bit of extra support to the `bootstrap` command to make sure that pre-existing `git` hooks do not interfere with the installation of the `pre-commit` `git` hooks.

## Security Considerations

* This change allows us to use multiple audit/security tools that hook into `git` without them conflicting with each other.