### PR TITLE
Add GovCloud S3 endpoints to allowlist

### DIFF
--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -10,3 +10,5 @@ gov-collector.newrelic.com
 egress-proxy-notify-api-staging.apps.internal
 idp.int.identitysandbox.gov
 secure.login.gov
+s3-fips.us-gov-east-1.amazonaws.com
+s3-fips.us-gov-west-1.amazonaws.com


### PR DESCRIPTION
Adds AWS GovCloud S3 endpoints to the allowlist.acl file to enable egress traffic from staging to:

- s3-fips.us-gov-east-1.amazonaws.com
- s3-fips.us-gov-west-1.amazonaws.com
Without them, the proxy is blocking S3