### PR TITLE
try to replace blocking sleep call with nonblocking sleep call

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 
 import botocore
+import eventlet
 from boto3 import Session
 from flask import current_app
 
@@ -375,7 +376,7 @@ def get_job_from_s3(service_id, job_id):
                 )
                 retries += 1
                 sleep_time = backoff_factor * (2**retries)  # Exponential backoff
-                time.sleep(sleep_time)
+                eventlet.sleep(sleep_time)
                 continue
             else:
                 # Typically this is "NoSuchKey"

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,6 +1,6 @@
 import json
-from time import sleep
 
+import eventlet
 from celery.signals import task_postrun
 from flask import current_app
 from requests import HTTPError, RequestException, request
@@ -83,7 +83,7 @@ def process_job(job_id, sender_id=None):
         process_row(row, template, job, service, sender_id=sender_id)
         count = count + 1
         if count % 3 == 0:
-            sleep(1)
+            eventlet.sleep(1)
 
     # End point/Exit point for message send flow.
     job_complete(job, start=start)

--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -151,7 +151,7 @@ class AwsCloudwatchClient(Client):
     #         result = temp_client.get_query_results(queryId=query_id)
     #         if result['status'] == 'Complete':
     #             break
-    #         time.sleep(1)
+    #         eventlet.sleep(1)
 
     #     delivery_receipts = []
     #     for log in result['results']:


### PR DESCRIPTION
## Description

The regenerate_job_cache() method, which has worked fine for about year, is not raising an exception that talks about not using blocking functions.  The exceptions are not pointing to our code but rather to eventlet underneath.

So, take a guess that there was a latent problem sitting there in the blocking calls to time.sleep() that we make, but that previous versions of gunicorn or python or eventlet (or whatever dependency got updated) were more forgiving and later versions have become stricter.  Replace time.sleep() (blocking) with eventlet.sleep() (non-blocking) and hope the problem goes away.

## Security Considerations

N/A