### PR TITLE
add sleep, more error handling, better debug message

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -224,11 +224,20 @@ def get_s3_files():
     current_app.logger.info(
         f"job_cache length before regen: {len_job_cache()} #notify-debug-admin-1200"
     )
+    count = 0
     try:
         for object_key in object_keys:
             read_s3_file(bucket_name, object_key, s3res)
+            count = count + 1
+            eventlet.sleep(0.2)
     except Exception:
-        current_app.logger.exception("Connection pool issue")
+        current_app.logger.exception(
+            f"Trouble reading {object_key} which is # {count} during cache regeneration"
+        )
+    except OSError:
+        current_app.logger.exception(
+            f"Egress proxy issue reading {object_key} which is # {count}"
+        )
 
     current_app.logger.info(
         f"job_cache length after regen: {len_job_cache()} #notify-debug-admin-1200"


### PR DESCRIPTION
## Description

Still working on the egress proxy error while regenerating the cache.  We can tell from the logs that the cache is either partially or fully generated, so not clear why egress proxy is throwing errors:

1.  Add a small sleep after we read each file
2. Improve the debug to show which # of csv file we died on, and the name of it.  Did we fail downloading #1 or number #73 etc.
3.  Try to absorb the OSError the proxy is throwing

## Security Considerations

N/A