### PR TITLE
switch to fips endpoint

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -80,7 +80,7 @@ def get_s3_client():
             aws_secret_access_key=secret_key,
             region_name=region,
         )
-        s3_client = session.client("s3")
+        s3_client = session.client("s3", config=AWS_CLIENT_CONFIG)
     return s3_client
 
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -1,7 +1,7 @@
 import os
 from datetime import timedelta
 from os import getenv
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import botocore
 import pytest
@@ -461,7 +461,7 @@ def test_get_s3_client(mocker):
     mock_session.return_value.client.return_value = mock_s3_client
     result = get_s3_client()
 
-    mock_session.return_value.client.assert_called_once_with("s3")
+    mock_session.return_value.client.assert_called_once_with("s3", config=ANY)
     assert result == mock_s3_client
 
 


### PR DESCRIPTION
## Description

Add the AWS config to the s3 client.  I think this  probably worked prior to the switch over to the FIPS endpoint, and then broke at that point.  Just hoping it works now.

## Security Considerations

N/A