### PR TITLE
Socket.IO 400 errors

### DIFF
--- a/application.py
+++ b/application.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from flask import Flask
 from werkzeug.serving import WSGIRequestHandler
 
-from app import create_app
+from app import create_app, socketio
 
 WSGIRequestHandler.version_string = lambda self: "SecureServer"
 


### PR DESCRIPTION
The issue might be that without importing socketio in application.py, gunicorn can't find the Socket.IO server to handle the WebSocket upgrade.