### PR TITLE
get rid of oscrypto

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -161,7 +161,7 @@
         "filename": ".github/workflows/daily_checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 63,
         "is_secret": false
       },
       {
@@ -169,7 +169,7 @@
         "filename": ".github/workflows/daily_checks.yml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 79,
         "is_secret": false
       }
     ],
@@ -384,5 +384,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-02T13:22:36Z"
+  "generated_at": "2025-06-04T15:02:41Z"
 }

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,15 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
       - name: Create requirements.txt
-        run: poetry export --output requirements_tmp.txt --without-hashes
-      - name: Filter requirements.txt
-        run: grep -v "oscrypto@ git" requirements_tmp.txt > requirements.txt
-      - name: Verify requirements.txt
-        run: ls -l requirements.txt
-      - name: Print requirements.txt
-        run: |
-          echo "Contents of requirements.txt:"
-          cat requirements.txt
+        run: poetry export --output requirements.txt
       - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           inputs: requirements.txt

--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -26,15 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-project
       - name: Create requirements.txt
-        run: poetry export --output requirements_tmp.txt --without-hashes
-      - name: Filter requirements.txt
-        run: grep -v "oscrypto@ git" requirements_tmp.txt > requirements.txt
-      - name: Verify requirements.txt
-        run: ls -l requirements.txt
-      - name: Print requirements.txt
-        run: |
-          echo "Contents of requirements.txt:"
-          cat requirements.txt
+        run: poetry export --output requirements.txt
       - uses: pypa/gh-action-pip-audit@v1.1.0
         with:
           inputs: requirements.txt

--- a/app/notifications/sns_cert_validator.py
+++ b/app/notifications/sns_cert_validator.py
@@ -2,14 +2,15 @@ import base64
 import re
 from urllib.parse import urlparse
 
-#import oscrypto.asymmetric
-#import oscrypto.errors
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import padding
-from cryptography.exceptions import InvalidSignature
 import requests
 import six
+
+# import oscrypto.asymmetric
+# import oscrypto.errors
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
 
 from app import redis_store
 from app.config import Config
@@ -122,18 +123,15 @@ def validate_sns_cert(sns_payload):
     try:
         public_key = certificate.public_key()
         public_key.verify(
-            signature,
-            string_to_sign,
-            padding.PKCS1v15(),
-            hashes.SHA256()  # or SHA1?
+            signature, string_to_sign, padding.PKCS1v15(), hashes.SHA256()  # or SHA1?
         )
-        #oscrypto.asymmetric.rsa_pkcs1v15_verify(
+        # oscrypto.asymmetric.rsa_pkcs1v15_verify(
         #    oscrypto.asymmetric.load_certificate(certificate),
         #    signature,
         #    string_to_sign,
         #    "sha1",
-        #)
+        # )
         return True
-    #except oscrypto.errors.SignatureError:
+    # except oscrypto.errors.SignatureError:
     except InvalidSignature:
         raise ValidationError("Invalid signature")

--- a/app/notifications/sns_cert_validator.py
+++ b/app/notifications/sns_cert_validator.py
@@ -4,9 +4,6 @@ from urllib.parse import urlparse
 
 import requests
 import six
-
-# import oscrypto.asymmetric
-# import oscrypto.errors
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
@@ -125,13 +122,6 @@ def validate_sns_cert(sns_payload):
         public_key.verify(
             signature, string_to_sign, padding.PKCS1v15(), hashes.SHA256()  # or SHA1?
         )
-        # oscrypto.asymmetric.rsa_pkcs1v15_verify(
-        #    oscrypto.asymmetric.load_certificate(certificate),
-        #    signature,
-        #    string_to_sign,
-        #    "sha1",
-        # )
         return True
-    # except oscrypto.errors.SignatureError:
     except InvalidSignature:
         raise ValidationError("Invalid signature")

--- a/poetry.lock
+++ b/poetry.lock
@@ -212,18 +212,6 @@ doc = ["doc8", "sphinx (>=7.0.0)", "sphinx-autobuild", "sphinx-autodoc-typehints
 test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytz (==2021.1)", "simplejson (==3.*)"]
 
 [[package]]
-name = "asn1crypto"
-version = "1.5.1"
-description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67"},
-    {file = "asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"},
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -3136,25 +3124,6 @@ files = [
 dev = ["black", "mypy", "pytest"]
 
 [[package]]
-name = "oscrypto"
-version = "1.3.0"
-description = "TLS (SSL) sockets, key generation, encryption, decryption, signing, verification and KDFs using the OS crypto libraries. Does not require a compiler, and relies on the OS for patching. Works on Windows, OS X and Linux/BSD."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = []
-develop = false
-
-[package.dependencies]
-asn1crypto = ">=1.5.1"
-
-[package.source]
-type = "git"
-url = "https://github.com/wbond/oscrypto.git"
-reference = "1547f53"
-resolved_reference = "1547f535001ba568b239b8797465536759c742a3"
-
-[[package]]
 name = "packageurl-python"
 version = "0.16.0"
 description = "A purl aka. Package URL parser and builder"
@@ -5608,4 +5577,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "12dd1482c9ad1e19d4edefb9fa0abf614346883c37dc600769bb3acf610410d4"
+content-hash = "879c7bb9dd451bb098c7a092498dd458224dcc766eb504fafe2cdc10255ccf7e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ marshmallow = "==3.26.1"
 marshmallow-sqlalchemy = "==1.0.0"
 newrelic = "*"
 notifications-python-client = "==10.0.1"
-oscrypto = { git = "https://github.com/wbond/oscrypto.git", rev = "1547f53" }
 packaging = "==25.0"
 poetry-dotenv-plugin = "==0.2.0"
 psycopg2-binary = "==2.9.10"


### PR DESCRIPTION
## Description

The oscrypto dependency is no longer being maintained.

It turns out, we only use it for one call -- a call that can be replaced with a call to the cryptography package, which we also have in our project.

## Security Considerations

Improves security by getting rid of a dependency that is not being maintained.