### PR TITLE
Unpin egress proxy release

### DIFF
--- a/.ds.baseline
+++ b/.ds.baseline
@@ -127,16 +127,6 @@
     }
   ],
   "results": {
-    ".github/actions/deploy-proxy/action.yml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".github/actions/deploy-proxy/action.yml",
-        "hashed_secret": "a6c13f5da3788e8d654cd24001dc79a238723248",
-        "is_verified": false,
-        "line_number": 18,
-        "is_secret": false
-      }
-    ],
     ".github/workflows/checks.yml": [
       {
         "type": "Secret Keyword",
@@ -384,5 +374,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-04T15:02:41Z"
+  "generated_at": "2025-06-04T16:02:28Z"
 }

--- a/.github/actions/deploy-proxy/action.yml
+++ b/.github/actions/deploy-proxy/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: https://github.com/GSA-TTS/cg-egress-proxy.git
   proxy_version:
     description: git ref to be deployed
-    default: 1500c67157c1a7a6fbbda7a2de172b3d0a67e703
+    default: main
 runs:
   using: composite
   steps:


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset unpins the egress proxy release now that we have resolved the other issues surrounding the connectivity to S3.

## Security Considerations

* We want to make sure we're able to keep the egress proxy up-to-date.
