### PR TITLE
Add one more cert environment variable

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -54,5 +54,6 @@ applications:
       SECRET_KEY: ((SECRET_KEY))
       AWS_US_TOLL_FREE_NUMBER: ((default_toll_free_number))
 
+      SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
       REQUESTS_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
       NEW_RELIC_CA_BUNDLE_PATH: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset adds an additional environment variable to enforce usage of the correct CA certificate in case any libraries override it.

Please see https://cloud.gov/docs/management/container-to-container/#addressing-certificate-validation-errors for more details.

## Security Considerations

* We want to make sure the proper certificates are used on the server side.
