### PR TITLE
Python manual unwind

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -9,10 +9,10 @@ runs:
         sudo apt-get update \
         && sudo apt-get install -y --no-install-recommends \
         libcurl4-openssl-dev
-    - name: Set up Python 3.13.2
+    - name: Set up Python 3.12.2
       uses: actions/setup-python@v4
       with:
-        python-version: "3.13.2"
+        python-version: "3.12.2"
     - name: Install poetry
       shell: bash
       run: pip install poetry==2.1.3

--- a/README.md
+++ b/README.md
@@ -259,12 +259,12 @@ git clone git@github.com:GSA/notifications-api.git
 
 Now go into the project directory (`notifications-api` by default), create a
 virtual environment, and set the local Python version to point to the virtual
-environment (assumes version Python `3.13.2` is what is installed on your
+environment (assumes version Python `3.12.2` is what is installed on your
 machine):
 
 ```sh
 cd notifications-api
-pyenv virtualenv 3.13.2 notify-api
+pyenv virtualenv 3.12.2 notify-api
 pyenv local notify-api
 ```
 
@@ -329,7 +329,7 @@ environment with the newer version of Python you just installed:
 
 ```sh
 cd notifications-api
-pyenv virtualenv 3.13.2 notify-api
+pyenv virtualenv 3.12.2 notify-api
 pyenv local notify-api
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -185,6 +185,7 @@ files = [
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 doc = ["Sphinx (>=8.2,<9.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
@@ -1368,6 +1369,9 @@ files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
     {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
 ]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
@@ -4191,6 +4195,7 @@ files = [
 [package.dependencies]
 attrs = ">=22.2.0"
 rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "regex"
@@ -5576,5 +5581,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13.2"
-content-hash = "879c7bb9dd451bb098c7a092498dd458224dcc766eb504fafe2cdc10255ccf7e"
+python-versions = "^3.12.2"
+content-hash = "d50366495a66aa4202ed504eacb7809597c4692043cb0ecec8d2e4c44a1ca088"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 
 [tool.poetry.dependencies]
-python = "^3.13.2"
+python = "^3.12.2"
 alembic = "==1.16.1"
 amqp = "==5.3.1"
 beautifulsoup4 = "==4.13.4"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.13.x
+python-3.12.x


### PR DESCRIPTION
## Description

Rollback to python 3.12.2 due to unfixable certificate issues.  Keep the improvements we made like getting rid of the oscrypto package.

## Security Considerations

The way python 3.12 handles certificates is less secure than how 3.13 handles them, but we don't have a choice at the moment.