### PR TITLE
add warning to log out before accepting invite

### DIFF
--- a/app/config_files/templates.json
+++ b/app/config_files/templates.json
@@ -20,6 +20,8 @@
       "Notify.gov makes it easy to keep people updated by helping you send text messages.",
       "",
       "",
+      "If you have not done so, please log out before joining.",
+      "",
       "[Join Service](((url)))",
       "If you’re new to Notify.gov you will first be directed to Login.gov create an account with us.",
       "",


### PR DESCRIPTION
## Description

Add a warning to invitations that user should log out prior to accepting.

NOTE: it's necessary to run the update-templates command to update this template on the various tiers

## Security Considerations

N/A