### PR TITLE
fix cronitor task name

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -30,8 +30,8 @@ from app.models import FactProcessingTime
 from app.utils import get_midnight_in_utc, utc_now
 
 
-@notify_celery.task(name="remove_sms_email_jobs")
-@cronitor("remove_sms_email_jobs")
+@notify_celery.task(name="remove-sms-email-jobs")
+@cronitor("remove-sms-email-jobs")
 def remove_sms_email_csv_files():
     _remove_csv_files([NotificationType.EMAIL, NotificationType.SMS])
 

--- a/app/config.py
+++ b/app/config.py
@@ -311,8 +311,8 @@ class Config(object):
                 "schedule": crontab(hour=4, minute=5),
                 "options": {"queue": QueueNames.PERIODIC},
             },
-            "remove_sms_email_jobs": {
-                "task": "remove_sms_email_jobs",
+            "remove-sms-email-jobs": {
+                "task": "remove-sms-email-jobs",
                 "schedule": crontab(hour=8, minute=0),
                 "options": {"queue": QueueNames.PERIODIC},
             },


### PR DESCRIPTION
## Description

Cronitor only runs on production.  In the production logs as of 7/8/2025 we were seeing the following error:

Cronitor enabled but task_name remove_sms_email_jobs not found in environment

This particular task is set up the same way as other tasks that do work, and cronitor on production is apparently using auto-discovery.   So the hypothesis is that the use of underscores in the task name is causing the problem.  All the working tasks use dashes.  This is at least a theoretical problem with cronitor, wherein both _ and - are theoretically allowed but auto-discovery could mess up with underscores.

So we can push this change to production and see if the problem is resolved.

## Security Considerations

N/A