### PR TITLE
fix celery bug

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -73,10 +73,12 @@ def delete_notifications_older_than_retention():
     )
 
 
+@notify_celery.task(name="delete-sms-notifications-older-than-retention")
 def delete_sms_notifications_older_than_retention():
     _delete_notifications_older_than_retention_by_type(NotificationType.SMS)
 
 
+@notify_celery.task(name="delete-email-notifications-older-than-retention")
 def delete_email_notifications_older_than_retention():
     _delete_notifications_older_than_retention_by_type(NotificationType.EMAIL)
 


### PR DESCRIPTION
## Description

Previous work to clean up legacy cronitor stuff from Notify UK inadvertently removed the @task annotations on a couple of methods, which are required so they can be run via apply_async()

## Security Considerations

N/A

