### PR TITLE
Celery tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ run-celery: ## Run celery, TODO remove purge for staging/prod
 		-A run_celery.notify_celery worker \
 		--pidfile="/tmp/celery.pid" \
 		--loglevel=INFO \
-		--pool=threads
-		--concurrency=10
+		--pool=eventlet
+		--concurrency=100
 
 
 .PHONY: dead-code

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -5,6 +5,7 @@ import time
 from io import StringIO
 
 import botocore
+import eventlet
 from boto3 import Session
 from flask import current_app
 
@@ -249,7 +250,7 @@ def get_s3_files():
         for object_key in object_keys:
             read_s3_file(bucket_name, object_key, s3res)
             count = count + 1
-            time.sleep(0.2)
+            eventlet.sleep(0.2)
     except Exception:
         current_app.logger.exception(
             f"Trouble reading {object_key} which is # {count} during cache regeneration"
@@ -410,7 +411,7 @@ def get_job_from_s3(service_id, job_id):
                 )
                 retries += 1
                 sleep_time = backoff_factor * (2**retries)  # Exponential backoff
-                time.sleep(sleep_time)
+                eventlet.sleep(sleep_time)
                 continue
             else:
                 # Typically this is "NoSuchKey"

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,6 +1,6 @@
 import json
-import time
 
+import eventlet
 from celery.signals import task_postrun
 from flask import current_app
 from requests import HTTPError, RequestException, request
@@ -84,7 +84,7 @@ def process_job(job_id, sender_id=None):
         process_row(row, template, job, service, sender_id=sender_id)
         count = count + 1
         if count % 3 == 0:
-            time.sleep(1)
+            eventlet.sleep(1)
 
     # End point/Exit point for message send flow.
     job_complete(job, start=start)

--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -151,7 +151,7 @@ class AwsCloudwatchClient(Client):
     #         result = temp_client.get_query_results(queryId=query_id)
     #         if result['status'] == 'Complete':
     #             break
-    #         time.sleep(1)
+    #         eventlet.sleep(1)
 
     #     delivery_receipts = []
     #     for log in result['results']:

--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,7 @@ applications:
       - type: worker
         instances: ((worker_instances))
         memory: ((worker_memory))
-        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=threads --concurrency=10 --prefetch-multiplier=2
+        command: newrelic-admin run-program celery -A run_celery.notify_celery worker --loglevel=INFO --pool=eventlet --concurrency=100 --prefetch-multiplier=2
       - type: scheduler
         instances: 1
         memory: ((scheduler_memory))


### PR DESCRIPTION
## Description

There's an incompatibility between our use of eventlet on the one hand, and starting up celery with pool=threads on the other.

Sounds like the python world is moving away from eventlet in favor of asyncio, and in the long run we might want to consider that.   But in the short run, let's just stabilize things in eventletland.

Set pool=eventlet, up the concurrency, and change time.sleep() to eventlet.sleep()

There are still a couple of possible blocking things in our code (serialized_models uses Threading.RLock, which doesn't sound good) but hopefully these changes reduce the frequency of the conflicts at least.

## Security Considerations

N/A