### PR TITLE
fix monkeypatching

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,13 +1,15 @@
-import os
-import socket
-import sys
-import traceback
-
 import eventlet
-import eventlet.debug as debug
-import gunicorn
 
-eventlet.monkey_patch()
+eventlet.monkey_patch()  # this has to be called before other imports or monkey patching doesn't happen
+
+import os  # noqa
+import socket  # noqa
+import sys  # noqa
+import traceback  # noqa
+
+import eventlet.debug as debug  # noqa
+import gunicorn  # noqa
+
 # This will give us a better stack trace if blocking occurs
 debug.hub_blocking_detection(True)
 workers = 4


### PR DESCRIPTION
## Description

Eventlet monkey patching has to happen before any major libraries are imported, otherwise we could be running with the original os or socket, which may block the main eventlet loop.


## Security Considerations

N/A