### PR TITLE
revert pip-system-certs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3216,21 +3216,6 @@ docs = ["Sphinx (>=3.3.1)", "doc8 (>=0.8.1)", "sphinx-rtd-theme (>=0.5.0)"]
 testing = ["aboutcode-toolkit (>=6.0.0)", "black", "pytest (>=6,!=7.0.0)", "pytest-xdist (>=2)"]
 
 [[package]]
-name = "pip-system-certs"
-version = "5.2"
-description = "Automatically configures Python to use system certificates via truststore"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "pip_system_certs-5.2-py3-none-any.whl", hash = "sha256:e6ef3e106d4d02313e33955c2bcc4c2b143b2da07ef91e28a6805a0c1c512126"},
-    {file = "pip_system_certs-5.2.tar.gz", hash = "sha256:80b776b5cf17191bf99d313699b7fce2fdb84eb7bbb225fd134109a82706406f"},
-]
-
-[package.dependencies]
-pip = ">=24.2"
-
-[[package]]
 name = "pkginfo"
 version = "1.12.1.2"
 description = "Query metadata from sdists / bdists / installed packages."
@@ -5548,4 +5533,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.9"
-content-hash = "fc1f421e42daf1e684b531406727942094973fe028cc4bad4d98891845a8deb0"
+content-hash = "6abf626cf2fee8ccaaee2087f0cf37244b829e7cbcace1287c7807747e70bd5c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ isort = "^6.0.1"
 jinja2-cli = {version = "==0.8.2", extras = ["yaml"]}
 moto = "==5.1.8"
 pip-audit = "*"
-pip-system-certs = "^5.2.0"
 pre-commit = "^4.2.0"
 pytest = "^8.4.0"
 pytest-env = "^1.1.3"


### PR DESCRIPTION
## Description

Revert pip-system-certs because it is broken.  It is recommended to use truststore instead.

## Security Considerations

N/A