### PR TITLE
clear up sqlalchemy warning

### DIFF
--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -119,7 +119,6 @@ def _delete_inbound_sms(datetime_to_delete_from, query_filter):
         select(InboundSms.id)
         .where(InboundSms.created_at < datetime_to_delete_from, *query_filter)
         .limit(query_limit)
-        .subquery()
     )
 
     deleted = 0

--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -119,6 +119,7 @@ def _delete_inbound_sms(datetime_to_delete_from, query_filter):
         select(InboundSms.id)
         .where(InboundSms.created_at < datetime_to_delete_from, *query_filter)
         .limit(query_limit)
+        .subquery()
     )
 
     deleted = 0
@@ -127,7 +128,7 @@ def _delete_inbound_sms(datetime_to_delete_from, query_filter):
     while number_deleted > 0:
         _insert_inbound_sms_history(subquery, query_limit=query_limit)
 
-        stmt = delete(InboundSms).where(InboundSms.id.in_(subquery))
+        stmt = delete(InboundSms).where(InboundSms.id.in_(select(subquery.c.id)))
         number_deleted = db.session.execute(stmt).rowcount
         db.session.commit()
         deleted += number_deleted


### PR DESCRIPTION
## Description

We are getting a sql alchemy warning currently in the logs:

home/vcap/app/app/dao/inbound_sms_dao.py:131: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly

So tidy that up.

## Security Considerations

N/A