### PR TITLE
try initializing new relic after we monkeypatch

### DIFF
--- a/gunicorn_entry.py
+++ b/gunicorn_entry.py
@@ -2,4 +2,8 @@ from gevent import monkey
 
 monkey.patch_all()
 
+import newrelic.agent  # noqa
+
+newrelic.agent.initialize("./newrelic.ini")
+
 from application import application  # noqa

--- a/poetry.lock
+++ b/poetry.lock
@@ -5645,4 +5645,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "4bdc474ed8c3825f1ae4f0e3ccb2de527f3a83d327843cca07fedc50493970bf"
+content-hash = "b40b20a277c88a4d73608c5c81c5c2dfb5bac46f00c9788b9705d13fecf520a4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ jsonschema = {version = "==4.25.0", extras = ["format"]}
 lxml = "==6.0.0"
 marshmallow = "^4.0.0"
 marshmallow-sqlalchemy = "^1.4.2"
-newrelic = "*"
+newrelic = "^10.15.0"
 packaging = "==25.0"
 poetry-dotenv-plugin = "==0.2.0"
 psycopg2-binary = "==2.9.10"

--- a/scripts/migrate_and_run_web.sh
+++ b/scripts/migrate_and_run_web.sh
@@ -4,4 +4,4 @@ if [[ $CF_INSTANCE_INDEX -eq 0 ]]; then
   flask db upgrade
 fi
 
-exec newrelic-admin run-program gunicorn -c ${HOME}/gunicorn_config.py gunicorn_entry:application
+exec gunicorn -c ${HOME}/gunicorn_config.py gunicorn_entry:application


### PR DESCRIPTION
## Description

We are having certificate errors with our python 3.13 upgrade.  In spite of the fact that we are monkey patching gevent at the top of a new gunicorn_entry.py file, there remains that fact that our app has to work with newrelic, and new relic may be messing things up for us as currently configured.

Move the instantiation of the newrelic agent from out in our script, into gunicorn_entry.py.  This ensures that gevent monkey patches everything before new relic starts running.

## Security Considerations

N/A
