### PR TITLE
change gunicorn timeout to 240 seconds

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,13 +2,19 @@ import os  # noqa
 import socket  # noqa
 import sys  # noqa
 import traceback  # noqa
+import logging
 
-import gunicorn  # noqa
+import gunicorn
+
+from app.utils import hilite  # noqa
 
 # This will give us a better stack trace if
 workers = 4
 worker_class = "gevent"
 worker_connections = 256
+logging.basicConfig(level=logging.INFO)
+logging.info(hilite("Gunicorn timeout set to 240 seconds"))
+timeout = 240
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 gunicorn.SERVER_SOFTWARE = "None"


### PR DESCRIPTION
## Description

We are timing out before our reports can complete.  Change the gunicorn timeout to 240 seconds.

## Security Considerations

N/A