### PR TITLE
try 60 seconds for timeout since we can't finish deploy for unknown r…

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,8 +1,8 @@
+import logging
 import os  # noqa
 import socket  # noqa
 import sys  # noqa
 import traceback  # noqa
-import logging
 
 import gunicorn
 
@@ -13,8 +13,8 @@ workers = 4
 worker_class = "gevent"
 worker_connections = 256
 logging.basicConfig(level=logging.INFO)
-logging.info(hilite("Gunicorn timeout set to 240 seconds"))
-timeout = 240
+timeout = 60
+logging.info(hilite(f"Gunicorn timeout set to {timeout} seconds"))
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 statsd_host = "{}:8125".format(os.getenv("STATSD_HOST"))
 gunicorn.SERVER_SOFTWARE = "None"


### PR DESCRIPTION


## Description

Change gunicorn timeout from ideal 240 seconds to 60 seconds just to see if the long timeout is causing the deploy failure.

## Security Considerations

N/A