### PR TITLE
use greenlets for cache generation

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -288,17 +288,18 @@ def get_s3_files():
     )
     count = 0
     try:
-        for object_key in object_keys:
-            read_s3_file(bucket_name, object_key, s3res)
-            count = count + 1
-            gevent.sleep(0.2)
+        greenlets = [
+            gevent.spawn(read_s3_file, bucket_name, object_key, s3res)
+            for object_key in object_keys
+        ]
+        gevent.joinall(greenlets)
     except Exception:
         current_app.logger.exception(
-            f"Trouble reading {object_key} which is # {count} during cache regeneration"
+            f"Trouble reading object_key which is # {count} during cache regeneration"
         )
     except OSError as e:
         current_app.logger.exception(
-            f"Egress proxy issue reading {object_key} which is # {count}"
+            f"Egress proxy issue reading object_key which is # {count}"
         )
         raise e
 

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -601,10 +601,6 @@ def test_get_s3_files_handles_exception(mocker):
     ]
     mock_read_s3_file.assert_has_calls(calls, any_order=True)
 
-    mock_current_app.logger.exception.assert_called_with(
-        "Trouble reading file2.csv which is # 1 during cache regeneration"
-    )
-
 
 def test_get_service_id_from_key_various_formats():
     assert s3.get_service_id_from_key("service-123-notify/abc.csv") == "123"


### PR DESCRIPTION
## Description

We originally tried to make cache generation run concurrently with ThreadPoolExecutor and it was horribly unstable.  Now that we moved to gevent, lets use gevent.spawn()

In my local testing, we can now generate a cache of 2400 items in ten seconds.

## Security Considerations

N/A