### PR TITLE
add the ability to query jobs based on processed started time rather than created_at

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -53,6 +53,7 @@ def dao_get_jobs_by_service_id(
     service_id,
     *,
     limit_days=None,
+    use_processing_time=False,
     page=1,
     page_size=50,
     statuses=None,
@@ -63,7 +64,12 @@ def dao_get_jobs_by_service_id(
         Job.original_file_name != current_app.config["ONE_OFF_MESSAGE_FILENAME"],
     ]
     if limit_days is not None:
-        query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))
+        if use_processing_time:
+            query_filter.append(
+                func.coalesce(Job.processing_started, Job.created_at) >= midnight_n_days_ago(limit_days)
+            )
+        else:
+            query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))
     if statuses is not None and statuses != [""]:
         query_filter.append(Job.job_status.in_(statuses))
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -220,6 +220,8 @@ def get_jobs_by_service(service_id):
     else:
         limit_days = None
 
+    use_processing_time = request.args.get("use_processing_time", "false").lower() == "true"
+
     valid_statuses = set(JobStatus)
     statuses_arg = request.args.get("statuses", "")
     if statuses_arg == "":
@@ -236,6 +238,7 @@ def get_jobs_by_service(service_id):
         **get_paginated_jobs(
             service_id,
             limit_days=limit_days,
+            use_processing_time=use_processing_time,
             statuses=statuses,
             page=int(request.args.get("page", 1)),
         )
@@ -325,12 +328,14 @@ def get_paginated_jobs(
     service_id,
     *,
     limit_days,
+    use_processing_time,
     statuses,
     page,
 ):
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,
+        use_processing_time=use_processing_time,
         page=page,
         page_size=current_app.config["PAGE_SIZE"],
         statuses=statuses,


### PR DESCRIPTION
This PR adds an option to filter jobs by the time they actually ran (processing_started) instead of when they were created. By default, the query filters by `created_at` but displays processing_started on the activity page, which creates a mismatch. Adding this new parameter will allow the front-end to filter by `processing_started` time on the Activity Page.

related admin pr: https://github.com/GSA/notifications-admin/pull/2815

<img width="978" height="478" alt="image" src="https://github.com/user-attachments/assets/1c5f463a-2891-4906-98a0-ada898e3bc8f" />


