### PR TITLE
Increase our disk quota in Cloud.gov

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
     buildpack: python_buildpack
     stack: cflinuxfs4
     instances: 1
-    disk_quota: 1G
+    disk_quota: 2G
     routes:
     - route: ((public_api_route))
     - route: notify-api-((env)).apps.internal


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset increases our allocated disk quota for the API to be 2G instead of 1G to ensure the app can be fully deployed.

## Security Considerations

* None; we need to make sure we can deploy our app.