### PR TITLE
fix updated_at

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -122,7 +122,6 @@ class User(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     _password = db.Column(db.String, index=False, unique=False, nullable=False)
@@ -376,7 +375,6 @@ class Organization(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     agreement_signed = db.Column(db.Boolean, nullable=True)
@@ -499,7 +497,6 @@ class Service(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     active = db.Column(
@@ -640,7 +637,6 @@ class AnnualBilling(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     created_at = db.Column(
@@ -719,7 +715,6 @@ class InboundNumber(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -775,7 +770,6 @@ class ServiceSmsSender(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -998,7 +992,6 @@ class ApiKey(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     created_by = db.relationship("User")
@@ -1267,8 +1260,7 @@ class TemplateRedacted(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=None,
-        onupdate=utc_now,
+        default=utc_now,
     )
     updated_by_id = db.Column(
         UUID(as_uuid=True),
@@ -1322,7 +1314,6 @@ class ProviderDetails(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     created_by_id = db.Column(
@@ -1344,9 +1335,7 @@ class ProviderDetailsHistory(db.Model, HistoryModel):
     notification_type = enum_column(NotificationType, nullable=False)
     active = db.Column(db.Boolean, nullable=False)
     version = db.Column(db.Integer, primary_key=True, nullable=False)
-    updated_at = db.Column(
-        db.DateTime, nullable=True, default=None, onupdate=utc_now
-    )
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=utc_now)
     created_by_id = db.Column(
         UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True
     )
@@ -1384,7 +1373,6 @@ class Job(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     notification_count = db.Column(db.Integer, nullable=False)
@@ -1528,7 +1516,6 @@ class Notification(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     status = enum_column(
@@ -1835,7 +1822,6 @@ class NotificationHistory(db.Model, HistoryModel):
         index=False,
         unique=False,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
     status = enum_column(
@@ -2122,7 +2108,6 @@ class ServiceEmailReplyTo(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -2169,7 +2154,6 @@ class FactBilling(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -2207,7 +2191,6 @@ class FactNotificationStatus(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -2226,7 +2209,6 @@ class FactProcessingTime(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -2294,7 +2276,6 @@ class ServiceDataRetention(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 
@@ -2349,7 +2330,6 @@ class WebauthnCredential(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=None,
         onupdate=utc_now,
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -115,14 +115,15 @@ class User(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     _password = db.Column(db.String, index=False, unique=False, nullable=False)
     mobile_number = db.Column(db.String, index=False, unique=False, nullable=True)
@@ -131,7 +132,7 @@ class User(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     logged_in_at = db.Column(db.DateTime, nullable=True)
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
@@ -144,7 +145,7 @@ class User(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     preferred_timezone = db.Column(
         db.Text,
@@ -370,12 +371,13 @@ class Organization(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     agreement_signed = db.Column(db.Boolean, nullable=True)
     agreement_signed_at = db.Column(db.DateTime, nullable=True)
@@ -490,14 +492,15 @@ class Service(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     active = db.Column(
         db.Boolean,
@@ -637,12 +640,13 @@ class AnnualBilling(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     UniqueConstraint(
         "financial_year_start",
@@ -709,13 +713,14 @@ class InboundNumber(db.Model):
     )
     created_at = db.Column(
         db.DateTime,
-        default=utc_now(),
+        default=utc_now,
         nullable=False,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     def serialize(self):
@@ -764,13 +769,14 @@ class ServiceSmsSender(db.Model):
     )
     created_at = db.Column(
         db.DateTime,
-        default=utc_now(),
+        default=utc_now,
         nullable=False,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     def get_reply_to_text(self):
@@ -809,7 +815,7 @@ class ServicePermission(db.Model):
     )
     created_at = db.Column(
         db.DateTime,
-        default=utc_now(),
+        default=utc_now,
         nullable=False,
     )
 
@@ -837,7 +843,7 @@ class ServiceGuestList(db.Model):
     service = db.relationship("Service", backref="guest_list")
     recipient_type = enum_column(RecipientType, nullable=False)
     recipient = db.Column(db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, default=utc_now())
+    created_at = db.Column(db.DateTime, default=utc_now)
 
     @classmethod
     def from_string(cls, service_id, recipient_type, recipient):
@@ -878,7 +884,7 @@ class ServiceInboundApi(db.Model, Versioned):
     _bearer_token = db.Column("bearer_token", db.String(), nullable=False)
     created_at = db.Column(
         db.DateTime,
-        default=utc_now(),
+        default=utc_now,
         nullable=False,
     )
     updated_at = db.Column(db.DateTime, nullable=True)
@@ -925,7 +931,7 @@ class ServiceCallbackApi(db.Model, Versioned):
     _bearer_token = db.Column("bearer_token", db.String(), nullable=False)
     created_at = db.Column(
         db.DateTime,
-        default=utc_now(),
+        default=utc_now,
         nullable=False,
     )
     updated_at = db.Column(db.DateTime, nullable=True)
@@ -985,14 +991,15 @@ class ApiKey(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     created_by = db.relationship("User")
     created_by_id = db.Column(
@@ -1112,9 +1119,9 @@ class TemplateBase(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
-    updated_at = db.Column(db.DateTime, onupdate=utc_now())
+    updated_at = db.Column(db.DateTime, onupdate=utc_now)
     content = db.Column(db.Text, nullable=False)
     archived = db.Column(db.Boolean, nullable=False, default=False)
     hidden = db.Column(db.Boolean, nullable=False, default=False)
@@ -1260,7 +1267,8 @@ class TemplateRedacted(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
+        default=utc_now,
     )
     updated_by_id = db.Column(
         UUID(as_uuid=True),
@@ -1314,7 +1322,8 @@ class ProviderDetails(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     created_by_id = db.Column(
         UUID(as_uuid=True),
@@ -1335,7 +1344,9 @@ class ProviderDetailsHistory(db.Model, HistoryModel):
     notification_type = enum_column(NotificationType, nullable=False)
     active = db.Column(db.Boolean, nullable=False)
     version = db.Column(db.Integer, primary_key=True, nullable=False)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=utc_now())
+    updated_at = db.Column(
+        db.DateTime, nullable=True, default=utc_now, onupdate=utc_now
+    )
     created_by_id = db.Column(
         UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True
     )
@@ -1366,14 +1377,15 @@ class Job(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     notification_count = db.Column(db.Integer, nullable=False)
     notifications_sent = db.Column(db.Integer, nullable=False, default=0)
@@ -1417,7 +1429,7 @@ class VerifyCode(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
 
     @property
@@ -1516,7 +1528,8 @@ class Notification(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     status = enum_column(
         NotificationStatus,
@@ -1822,7 +1835,8 @@ class NotificationHistory(db.Model, HistoryModel):
         index=False,
         unique=False,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
     status = enum_column(
         NotificationStatus,
@@ -1891,7 +1905,7 @@ class InvitedUser(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     status = enum_column(
         InvitedUserStatus,
@@ -1930,7 +1944,7 @@ class InvitedOrganizationUser(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
 
     status = enum_column(
@@ -1976,7 +1990,7 @@ class Permission(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
 
     __table_args__ = (
@@ -1999,7 +2013,7 @@ class Event(db.Model):
         index=False,
         unique=False,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     data = db.Column(JSON, nullable=False)
 
@@ -2023,7 +2037,7 @@ class InboundSms(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     service_id = db.Column(
         UUID(as_uuid=True),
@@ -2103,12 +2117,13 @@ class ServiceEmailReplyTo(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     def serialize(self):
@@ -2149,12 +2164,13 @@ class FactBilling(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
 
@@ -2186,12 +2202,13 @@ class FactNotificationStatus(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
 
@@ -2204,12 +2221,13 @@ class FactProcessingTime(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
 
@@ -2232,7 +2250,7 @@ class Complaint(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
 
     def serialize(self):
@@ -2271,12 +2289,13 @@ class ServiceDataRetention(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     __table_args__ = (
@@ -2325,12 +2344,13 @@ class WebauthnCredential(db.Model):
     created_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now(),
+        default=utc_now,
     )
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=utc_now(),
+        default=utc_now,
+        onupdate=utc_now,
     )
 
     def serialize(self):

--- a/app/models.py
+++ b/app/models.py
@@ -122,7 +122,7 @@ class User(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     _password = db.Column(db.String, index=False, unique=False, nullable=False)
@@ -376,7 +376,7 @@ class Organization(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     agreement_signed = db.Column(db.Boolean, nullable=True)
@@ -499,7 +499,7 @@ class Service(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     active = db.Column(
@@ -640,7 +640,7 @@ class AnnualBilling(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     created_at = db.Column(
@@ -719,7 +719,7 @@ class InboundNumber(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -775,7 +775,7 @@ class ServiceSmsSender(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -998,7 +998,7 @@ class ApiKey(db.Model, Versioned):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     created_by = db.relationship("User")
@@ -1267,7 +1267,7 @@ class TemplateRedacted(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=False,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     updated_by_id = db.Column(
@@ -1322,7 +1322,7 @@ class ProviderDetails(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     created_by_id = db.Column(
@@ -1345,7 +1345,7 @@ class ProviderDetailsHistory(db.Model, HistoryModel):
     active = db.Column(db.Boolean, nullable=False)
     version = db.Column(db.Integer, primary_key=True, nullable=False)
     updated_at = db.Column(
-        db.DateTime, nullable=True, default=utc_now, onupdate=utc_now
+        db.DateTime, nullable=True, default=None, onupdate=utc_now
     )
     created_by_id = db.Column(
         UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True
@@ -1384,7 +1384,7 @@ class Job(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     notification_count = db.Column(db.Integer, nullable=False)
@@ -1528,7 +1528,7 @@ class Notification(db.Model):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     status = enum_column(
@@ -1835,7 +1835,7 @@ class NotificationHistory(db.Model, HistoryModel):
         index=False,
         unique=False,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
     status = enum_column(
@@ -2122,7 +2122,7 @@ class ServiceEmailReplyTo(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -2169,7 +2169,7 @@ class FactBilling(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -2207,7 +2207,7 @@ class FactNotificationStatus(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -2226,7 +2226,7 @@ class FactProcessingTime(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -2294,7 +2294,7 @@ class ServiceDataRetention(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 
@@ -2349,7 +2349,7 @@ class WebauthnCredential(db.Model):
     updated_at = db.Column(
         db.DateTime,
         nullable=True,
-        default=utc_now,
+        default=None,
         onupdate=utc_now,
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -1268,7 +1268,7 @@ class TemplateRedacted(db.Model):
         db.DateTime,
         nullable=False,
         default=utc_now,
-        default=utc_now,
+        onupdate=utc_now,
     )
     updated_by_id = db.Column(
         UUID(as_uuid=True),

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -33,10 +33,9 @@ def test_dao_get_reply_to_by_service_id(notify_db_session):
     results = dao_get_reply_to_by_service_id(service_id=service.id)
 
     assert len(results) == 3
-    # TODO we had to change the order around, why?
     assert default_reply_to == results[0]
-    assert another_reply_to == results[2]
-    assert second_reply_to == results[1]
+    assert another_reply_to == results[1]
+    assert second_reply_to == results[2]
 
 
 def test_dao_get_reply_to_by_service_id_does_not_return_archived_reply_tos(

--- a/tests/app/webauthn/test_rest.py
+++ b/tests/app/webauthn/test_rest.py
@@ -29,7 +29,7 @@ def test_get_webauthn_credentials_returns_all_credentials_for_user(
         "name": "1",
         "credential_data": "ABC123",
         "created_at": ANY,
-        "updated_at": None,
+        "updated_at": ANY,
     }
 
     assert creds[1]["name"] == "2"


### PR DESCRIPTION
## Description

The issue originally reported almost 2 years ago was that the Notification.updated_at field was updating continuously, and the change in the value had nothing to do with when the object was actually updated.

I'm not seeing that now -- not reproducible.

However, setting:

onupdate=utc_now()

instead of 

onupdated=utcnow

means that the value gets fixed at the time the models classes load, and then stays frozen, which is not what we want.  So fix that.

## Security Considerations

N/A
