### PR TITLE
Only the person who creates the folder and admin gets default folder permissions

### DIFF
--- a/app/template_folder/rest.py
+++ b/app/template_folder/rest.py
@@ -60,7 +60,11 @@ def create_template_folder(service_id):
         except NoResultFound:
             raise InvalidRequest("parent_id not found", status_code=400)
     else:
-        users_with_permission = dao_get_active_service_users(service_id)
+        users_with_permission = []
+        if data.get("created_by_id"):
+            creator = dao_get_service_user(data["created_by_id"], service_id)
+            if creator:
+                users_with_permission = [creator]
     template_folder = TemplateFolder(
         service_id=service_id,
         name=data["name"].strip(),

--- a/app/template_folder/rest.py
+++ b/app/template_folder/rest.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.dao_utils import autocommit
-from app.dao.service_user_dao import dao_get_active_service_users, dao_get_service_user
+from app.dao.service_user_dao import dao_get_service_user
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.template_folder_dao import (
     dao_create_template_folder,

--- a/app/template_folder/template_folder_schema.py
+++ b/app/template_folder/template_folder_schema.py
@@ -7,6 +7,7 @@ post_create_template_folder_schema = {
     "properties": {
         "name": {"type": "string", "minLength": 1},
         "parent_id": nullable_uuid,
+        "created_by_id": uuid,
     },
     "required": ["name", "parent_id"],
 }

--- a/tests/app/template_folder/test_template_folder_rest.py
+++ b/tests/app/template_folder/test_template_folder_rest.py
@@ -125,9 +125,25 @@ def test_create_template_folder_sets_user_permissions(
     if has_parent:
         assert resp["data"]["users_with_permission"] == [str(user_1.id)]
     else:
-        assert sorted(resp["data"]["users_with_permission"]) == sorted(
-            [str(user_1.id), str(user_2.id)]
-        )
+        assert resp["data"]["users_with_permission"] == []
+
+
+def test_create_template_folder_with_creator_id_grants_permission_to_creator(
+    admin_request, sample_service
+):
+    user_1 = create_user(email="creator@gsa.gov")
+    user_2 = create_user(email="other@gsa.gov")
+    sample_service.users = [user_1, user_2]
+
+    resp = admin_request.post(
+        "template_folder.create_template_folder",
+        service_id=sample_service.id,
+        _data={"name": "creator folder", "parent_id": None, "created_by_id": str(user_1.id)},
+        _expected_status=201,
+    )
+
+    assert resp["data"]["name"] == "creator folder"
+    assert resp["data"]["users_with_permission"] == [str(user_1.id)]
 
 
 @pytest.mark.parametrize("missing_field", ["name", "parent_id"])


### PR DESCRIPTION
- Only the user who creates the folder and platform_admin gets default folder permissions
- Folders are private by default, others must be manually added

Related admin branch: https://github.com/GSA/notifications-admin/pull/2841
Issue: Bug: When a new template folder is added, existing users are automatically given permission to it
[#2795](https://github.com/GSA/notifications-admin/issues/2795)