### PR TITLE
Fix Demo environment SSB AWS regions

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -60,7 +60,7 @@ module "ses_email" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
-  aws_region          = "us-west-2"
+  aws_region          = "us-gov-west-1"
   email_domain        = "notify.sandbox.10x.gsa.gov"
   email_receipt_error = "notify-support@gsa.gov"
 }
@@ -71,6 +71,6 @@ module "sns_sms" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-sns-${local.env}"
-  aws_region          = "us-east-1"
+  aws_region          = "us-gov-west-1"
   monthly_spend_limit = 25
 }


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

The AWS regions for the SSBs in the demo environment were incorrect; this should fix them and get things working properly with the brokered SNS and SES services.

## Security Considerations

* None; this a fix to AWS region references.