### PR TITLE
Update Demo SSB References Again

### DIFF
--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -60,8 +60,8 @@ module "ses_email" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-ses-${local.env}"
-  aws_region          = "us-gov-west-1"
-  email_domain        = "notify.sandbox.10x.gsa.gov"
+  aws_region          = "us-west-2"
+  mail_from_subdomain = "mail"
   email_receipt_error = "notify-support@gsa.gov"
 }
 
@@ -71,6 +71,6 @@ module "sns_sms" {
   cf_org_name         = local.cf_org_name
   cf_space_name       = local.cf_space_name
   name                = "${local.app_name}-sns-${local.env}"
-  aws_region          = "us-gov-west-1"
+  aws_region          = "us-west-2"
   monthly_spend_limit = 25
 }


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

After double checking the configuration of the Notify SSB and how the brokerpaks are used with it, the configuration of demo should actually match that of our staging environment, not production because the demo environment is using the staging SSB.  This changeset updates the Demo SSB configuration to match that.

The reason for this is because the staging SSB is deployed into the corresponding staging AWS account, _not_ the demo AWS account.

## Security Considerations

* None; this is correcting an error with our Demo environment SSB configuration.