### PR TITLE
add log statement when our send quota is used up

### DIFF
--- a/app/clients/cloudwatch/aws_cloudwatch.py
+++ b/app/clients/cloudwatch/aws_cloudwatch.py
@@ -7,6 +7,7 @@ from flask import current_app
 
 from app.clients import AWS_CLIENT_CONFIG, Client
 from app.cloudfoundry_config import cloud_config
+from app.utils import hilite
 
 
 class AwsCloudwatchClient(Client):
@@ -178,6 +179,13 @@ class AwsCloudwatchClient(Client):
         )
         failed_event_set = self._get_receipts(log_group_name, start, end)
         current_app.logger.info((f"Failed message count: {len(failed_event_set)}"))
+
+        for failure in failed_event_set:
+            failure = json.loads(failure)
+            if "No quota left for account" == failure["delivery.providerResponse"]:
+                current_app.logger.warning(
+                    hilite("**********NO QUOTA LEFT TO SEND MESSAGES!!!**********")
+                )
 
         return delivered_event_set, failed_event_set
 


### PR DESCRIPTION
## Description

When we use up our send quota in development and can no longer send messages that way, there was no indication of that other than in the downloadable reports, which show the "delivery.providerResponse" from the delivery receipts.  Add a debug message to the logs when the quota is used up, because it's non-obvious reason for failure and doesn't cause exceptions etc.

## Security Considerations

N/A