### PR TITLE
lazy initialize for gevent

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -122,7 +122,7 @@ def get_zendesk_client():
     if os.environ.get("NOTIFY_ENVIRONMENT") == "test":
         return None
     if zendesk_client is None:
-        raise RuntimeError(f"Celery not initialized zendesk_client: {zendesk_client}")
+        zendesk_client = ZendeskClient()
     return zendesk_client
 
 
@@ -148,6 +148,7 @@ def get_document_download_client():
 
 
 def create_app(application):
+    global zendesk_client, migrate, document_download_client, aws_ses_client, aws_ses_stub_client
     from app.config import configs
 
     notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
@@ -170,7 +171,8 @@ def create_app(application):
     # start lazy initialization for gevent
     migrate = Migrate()
     migrate.init_app(application, db=db)
-    zendesk_client = ZendeskClient()
+    if zendesk_client is None:
+        zendesk_client = ZendeskClient()
     zendesk_client.init_app(application)
     document_download_client = DocumentDownloadClient()
     document_download_client.init_app(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -126,6 +126,15 @@ def get_zendesk_client():
     return zendesk_client
 
 
+def get_aws_ses_client():
+    global aws_ses_client
+    if os.environ.get("NOTIFY_ENVIRONMENT") == "test":
+        return AwsSesClient()
+    if aws_ses_client is None:
+        raise RuntimeError(f"Celery not initialized aws_ses_client: {aws_ses_client}")
+    return aws_ses_client
+
+
 def get_document_download_client():
     global document_download_client
     # Our unit tests mock anyway

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -92,7 +92,7 @@ db = SQLAlchemy(
 )
 migrate = None
 notify_celery = NotifyCelery()
-aws_ses_client = AwsSesClient()
+aws_ses_client = None
 aws_ses_stub_client = None
 aws_sns_client = AwsSnsClient()
 aws_cloudwatch_client = None
@@ -158,8 +158,6 @@ def create_app(application):
     logging.init_app(application)
     aws_sns_client.init_app(application)
 
-    aws_ses_client.init_app()
-
     # start lazy initialization for gevent
     migrate = Migrate()
     migrate.init_app(application, db=db)
@@ -169,6 +167,8 @@ def create_app(application):
     document_download_client.init_app(application)
     aws_cloudwatch_client = AwsCloudwatchClient()
     aws_cloudwatch_client.init_app(application)
+    aws_ses_client = AwsSesClient()
+    aws_ses_client.init_app()
     aws_ses_stub_client = AwsSesStubClient()
     aws_ses_stub_client.init_app(stub_url=application.config["SES_STUB_URL"])
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,7 +95,7 @@ notify_celery = NotifyCelery()
 aws_ses_client = AwsSesClient()
 aws_ses_stub_client = None
 aws_sns_client = AwsSnsClient()
-aws_cloudwatch_client = AwsCloudwatchClient()
+aws_cloudwatch_client = None
 encryption = Encryption()
 zendesk_client = None
 redis_store = RedisClient()
@@ -159,7 +159,6 @@ def create_app(application):
     aws_sns_client.init_app(application)
 
     aws_ses_client.init_app()
-    aws_cloudwatch_client.init_app(application)
 
     # start lazy initialization for gevent
     migrate = Migrate()
@@ -168,7 +167,8 @@ def create_app(application):
     zendesk_client.init_app(application)
     document_download_client = DocumentDownloadClient()
     document_download_client.init_app(application)
-
+    aws_cloudwatch_client = AwsCloudwatchClient()
+    aws_cloudwatch_client.init_app(application)
     aws_ses_stub_client = AwsSesStubClient()
     aws_ses_stub_client.init_app(stub_url=application.config["SES_STUB_URL"])
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -5,7 +5,7 @@ from flask import current_app
 from sqlalchemy import between, select, union
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import db, notify_celery, redis_store, zendesk_client
+from app import db, get_zendesk_client, notify_celery, redis_store
 from app.celery.tasks import (
     get_recipient_csv_and_template_and_sender_id,
     process_incomplete_jobs,
@@ -43,6 +43,8 @@ from notifications_utils import aware_utcnow
 from notifications_utils.clients.zendesk.zendesk_client import NotifySupportTicket
 
 MAX_NOTIFICATION_FAILS = 10000
+
+zendesk_client = get_zendesk_client()
 
 
 @notify_celery.task(name="run-scheduled-jobs")

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -49,7 +49,6 @@ register_errors(job_blueprint)
 
 @job_blueprint.route("/<job_id>", methods=["GET"])
 def get_job_by_service_and_job_id(service_id, job_id):
-    current_app.logger.info(hilite("ENTER get_job_by_service_and_job_id"))
     check_suspicious_id(service_id, job_id)
     job = dao_get_job_by_service_id_and_job_id(service_id, job_id)
     statistics = dao_get_notification_outcomes_for_job(service_id, job_id)
@@ -150,7 +149,6 @@ def get_all_notifications_for_service_job(service_id, job_id):
         notifications = notification_with_template_schema.dump(
             paginated_notifications.items, many=True
         )
-        current_app.logger.info(hilite("Got the dumped notifications and returning"))
 
     return (
         jsonify(

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ xfail_strict=true
 exclude = venv*,__pycache__,node_modules,cache,migrations,build,sample_cap_xml_documents.py
 max-line-length = 120
 # W504 line break after binary operator
-extend_ignore=B306, W504, E203
+extend_ignore=B306, W504, E203, F824
 
 [isort]
 profile = black

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -498,10 +498,9 @@ def test_check_for_services_with_high_failure_rates_or_sending_to_tv_numbers(
 ):
     mock_logger = mocker.patch("app.celery.tasks.current_app.logger.warning")
     mock_create_ticket = mocker.spy(NotifySupportTicket, "__init__")
-    mock_send_ticket_to_zendesk = mocker.patch(
-        "app.celery.scheduled_tasks.zendesk_client.send_ticket_to_zendesk",
-        autospec=True,
-    )
+    mock_zendesk_client = MagicMock()
+    mocker.patch("app.celery.scheduled_tasks.zendesk_client", mock_zendesk_client)
+    mock_send_ticket_to_zendesk = mock_zendesk_client.send_ticket_to_zendesk
     mock_failure_rates = mocker.patch(
         "app.celery.scheduled_tasks.dao_find_services_with_high_failure_rates",
         return_value=failure_rates,

--- a/tests/app/clients/test_aws_cloudwatch.py
+++ b/tests/app/clients/test_aws_cloudwatch.py
@@ -7,8 +7,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from flask import current_app
 
-from app import aws_cloudwatch_client
 from app.clients.cloudwatch.aws_cloudwatch import AwsCloudwatchClient
+
+aws_cloudwatch_client = MagicMock()
 
 
 def test_check_sms_no_event_error_condition(notify_api, mocker):

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -1,12 +1,13 @@
 import json
 from unittest import mock
-from unittest.mock import ANY, MagicMock, Mock
+from unittest.mock import ANY, Mock
 
 import botocore
 import pytest
 
 from app.clients.email import EmailClientNonRetryableException
 from app.clients.email.aws_ses import (
+    AwsSesClient,
     AwsSesClientException,
     AwsSesClientThrottlingSendRateException,
     get_aws_responses,
@@ -14,8 +15,6 @@ from app.clients.email.aws_ses import (
 from app.clients.email.aws_ses_stub import AwsSesStubClient
 from app.enums import NotificationStatus, StatisticsType
 
-# comes from app/__init__.py but we mock it for the tests
-aws_ses_client = MagicMock()
 
 
 def test_should_return_correct_details_for_delivery():
@@ -68,6 +67,8 @@ def test_should_be_none_if_unrecognised_status_code():
 def test_send_email_handles_reply_to_address(
     notify_api, mocker, reply_to_address, expected_value
 ):
+    aws_ses_client = AwsSesClient()
+
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
 
     with notify_api.app_context():
@@ -85,6 +86,7 @@ def test_send_email_handles_reply_to_address(
 
 
 def test_send_email_handles_punycode_to_address(notify_api, mocker):
+    aws_ses_client = AwsSesClient()
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
 
     with notify_api.app_context():
@@ -107,6 +109,7 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
 def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetryableException(
     mocker,
 ):
+    aws_ses_client = AwsSesClient()
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
     error_response = {
         "Error": {
@@ -133,6 +136,7 @@ def test_send_email_raises_invalid_parameter_value_error_as_EmailClientNonRetrya
 def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRateException(
     mocker,
 ):
+    aws_ses_client = AwsSesClient()
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
     error_response = {
         "Error": {
@@ -154,6 +158,7 @@ def test_send_email_raises_send_rate_throttling_as_AwsSesClientThrottlingSendRat
 def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_non_send_rate_throttling(
     mocker,
 ):
+    aws_ses_client = AwsSesClient()
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
     error_response = {
         "Error": {
@@ -173,6 +178,7 @@ def test_send_email_does_not_raise_AwsSesClientThrottlingSendRateException_if_no
 
 
 def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
+    aws_ses_client = AwsSesClient()
     boto_mock = mocker.patch.object(aws_ses_client, "_client", create=True)
     error_response = {
         "Error": {

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -16,7 +16,6 @@ from app.clients.email.aws_ses_stub import AwsSesStubClient
 from app.enums import NotificationStatus, StatisticsType
 
 
-
 def test_should_return_correct_details_for_delivery():
     response_dict = get_aws_responses("Delivery")
     assert response_dict["message"] == "Delivered"

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -1,18 +1,21 @@
 import json
 from unittest import mock
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY, MagicMock, Mock
 
 import botocore
 import pytest
 
-from app import AwsSesStubClient, aws_ses_client
 from app.clients.email import EmailClientNonRetryableException
 from app.clients.email.aws_ses import (
     AwsSesClientException,
     AwsSesClientThrottlingSendRateException,
     get_aws_responses,
 )
+from app.clients.email.aws_ses_stub import AwsSesStubClient
 from app.enums import NotificationStatus, StatisticsType
+
+# comes from app/__init__.py but we mock it for the tests
+aws_ses_client = MagicMock()
 
 
 def test_should_return_correct_details_for_delivery():

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -163,11 +163,11 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         reply_to_address=None,
     )
 
-    assert "<!DOCTYPE html" in app.aws_ses_client.send_email.call_args[1]["html_body"]
-    assert (
-        "&lt;em&gt;some HTML&lt;/em&gt;"
-        in app.aws_ses_client.send_email.call_args[1]["html_body"]
-    )
+    # assert "<!DOCTYPE html" in app.aws_ses_client.send_email.call_args[1]["html_body"]
+    # assert (
+    #    "&lt;em&gt;some HTML&lt;/em&gt;"
+    #    in app.aws_ses_client.send_email.call_args[1]["html_body"]
+    # )
 
     notification = (
         db.session.execute(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -142,9 +142,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         template=sample_email_template_with_html,
     )
     db_notification.personalisation = {"name": "Jo"}
-    mock_ses_client = MagicMock()
-    mock_ses_client.send_email.return_value = "reference"
-    mocker.patch("app.aws_ses_client", mock_ses_client)
+    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     send_to_providers.send_email_to_provider(db_notification)
     app.aws_ses_client.send_email.assert_called_once_with(
         f'"Sample service" <sample.service@{cloud_config.ses_email_domain}>',
@@ -178,9 +176,7 @@ def test_should_not_send_email_message_when_service_is_inactive_notifcation_is_i
     sample_service, sample_notification, mocker
 ):
     sample_service.active = False
-    mock_ses_client = MagicMock()
-    mock_ses_client.send_email.return_value = "reference"
-    send_mock = mocker.patch("app.aws_ses_client", mock_ses_client)
+    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
     mock_s3.return_value = "2028675309"
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -907,7 +907,7 @@ def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_te
     )
 
 
-def test_send_email_to_provider_should_user_normalised_to(
+def test_send_email_to_provider_should_use_normalised_to(
     mocker, client, sample_email_template
 ):
     mock_boto_client = mocker.patch("boto3.client")
@@ -935,7 +935,7 @@ def test_send_email_to_provider_should_user_normalised_to(
     mock_redis.get.side_effect = [email, personalisation]
 
     send_to_providers.send_email_to_provider(notification)
-    mock_ses.assert_called_once_with(
+    mock_ses.send_email.assert_called_once_with(
         ANY,
         "test@example.com",
         ANY,
@@ -1057,7 +1057,7 @@ def test_send_email_to_provider_should_return_template_if_found_in_redis(
     send_to_providers.send_email_to_provider(notification)
     assert mock_get_template.called is False
     assert mock_get_service.called is False
-    mock_ses.assert_called_once_with(
+    mock_ses.send_email.assert_called_once_with(
         ANY,
         "test@example.com",
         ANY,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1,6 +1,6 @@
 import json
 from collections import namedtuple
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from flask import current_app
@@ -142,7 +142,9 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         template=sample_email_template_with_html,
     )
     db_notification.personalisation = {"name": "Jo"}
-    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    mocker.patch("app.aws_ses_client", mock_ses_client)
     send_to_providers.send_email_to_provider(db_notification)
     app.aws_ses_client.send_email.assert_called_once_with(
         f'"Sample service" <sample.service@{cloud_config.ses_email_domain}>',
@@ -176,7 +178,9 @@ def test_should_not_send_email_message_when_service_is_inactive_notifcation_is_i
     sample_service, sample_notification, mocker
 ):
     sample_service.active = False
-    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    send_mock = mocker.patch("app.aws_ses_client", mock_ses_client)
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
     mock_s3.return_value = "2028675309"
 
@@ -419,7 +423,8 @@ def test_send_email_to_provider_should_not_send_to_provider_when_status_is_not_c
     notification = create_notification(
         template=sample_email_template, status=NotificationStatus.SENDING
     )
-    mocker.patch("app.aws_ses_client.send_email")
+    mock_ses_client = MagicMock()
+    mocker.patch("app.aws_ses_client", mock_ses_client)
     mocker.patch("app.delivery.send_to_providers.send_email_response")
 
     mocker.patch("app.delivery.send_to_providers.update_notification_message_id")
@@ -438,7 +443,9 @@ def test_send_email_to_provider_should_not_send_to_provider_when_status_is_not_c
 def test_send_email_should_use_service_reply_to_email(
     sample_service, sample_email_template, mocker
 ):
-    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    mocker.patch("app.aws_ses_client", mock_ses_client)
 
     mock_redis = mocker.patch("app.delivery.send_to_providers.redis_store")
     mock_redis.get.return_value = "test@example.com".encode("utf-8")
@@ -819,8 +826,9 @@ def test_send_email_to_provider_uses_reply_to_from_notification(
         "test@example.com".encode("utf-8"),
         json.dumps({}).encode("utf-8"),
     ]
-
-    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    mocker.patch("app.aws_ses_client", mock_ses_client)
 
     db_notification = create_notification(
         template=sample_email_template,
@@ -878,7 +886,9 @@ def test_send_sms_to_provider_should_use_normalised_to(mocker, client, sample_te
 def test_send_email_to_provider_should_user_normalised_to(
     mocker, client, sample_email_template
 ):
-    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    send_mock = mocker.patch("app.aws_ses_client", mock_ses_client)
     notification = create_notification(
         template=sample_email_template,
     )
@@ -995,7 +1005,9 @@ def test_send_email_to_provider_should_return_template_if_found_in_redis(
         "app.dao.templates_dao.dao_get_template_by_id_and_service_id"
     )
     mock_get_service = mocker.patch("app.dao.services_dao.dao_fetch_service_by_id")
-    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mock_ses_client = MagicMock()
+    mock_ses_client.send_email.return_value = "reference"
+    send_mock = mocker.patch("app.aws_ses_client", mock_ses_client)
     notification = create_notification(
         template=sample_email_template,
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -147,7 +147,6 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     mock_client.send_email.return_value = "reference"
     mocker.patch("app.aws_ses_client", mock_client)
 
-    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     send_to_providers.send_email_to_provider(db_notification)
     app.aws_ses_client.send_email.assert_called_once_with(
         f'"Sample service" <sample.service@{cloud_config.ses_email_domain}>',
@@ -185,6 +184,7 @@ def test_should_not_send_email_message_when_service_is_inactive_notifcation_is_i
     mock_client = MagicMock()
     mock_client.send_email.return_value = "reference"
     mocker.patch("app.aws_ses_client", mock_client)
+
     mock_s3 = mocker.patch("app.delivery.send_to_providers.get_phone_number_from_s3")
     mock_s3.return_value = "2028675309"
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -147,6 +147,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     mock_ses = MagicMock()
     mock_boto_client.return_value = mock_ses
     mock_ses.send_email.return_value = "reference"
+    mock_ses.name = "ses"
     mocker.patch(
         "app.notification_provider_clients.get_client_by_name_and_type",
         return_value=mock_ses,

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -973,6 +973,10 @@ def test_send_sms_to_provider_should_return_template_if_found_in_redis(
     )
     mock_personalisation.return_value = {"ignore": "ignore"}
 
+    mock_client = MagicMock()
+    mock_client.send_email.return_value = "reference"
+    mocker.patch("app.aws_ses_client", mock_client)
+
     send_to_providers.send_sms_to_provider(notification)
     assert mock_get_template.called is False
     assert mock_get_service.called is False
@@ -1017,9 +1021,16 @@ def test_send_email_to_provider_should_return_template_if_found_in_redis(
         "app.dao.templates_dao.dao_get_template_by_id_and_service_id"
     )
     mock_get_service = mocker.patch("app.dao.services_dao.dao_fetch_service_by_id")
+
     mock_ses_client = MagicMock()
     mock_ses_client.send_email.return_value = "reference"
     send_mock = mocker.patch("app.aws_ses_client", mock_ses_client)
+    mock_ses_client.name = "ses"
+    mocker.patch(
+        "app.notification_provider_clients.get_client_by_name_and_type",
+        return_value=mock_ses_client,
+    )
+
     notification = create_notification(
         template=sample_email_template,
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -9,7 +9,6 @@ from sqlalchemy import select
 
 import app
 from app import aws_sns_client, db, notification_provider_clients
-from app.clients.email.aws_ses import AwsSesClient
 from app.cloudfoundry_config import cloud_config
 from app.dao import notifications_dao
 from app.dao.provider_details_dao import get_provider_details_by_identifier
@@ -144,8 +143,8 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     )
     db_notification.personalisation = {"name": "Jo"}
 
-    mock_client = AwsSesClient()
-    mock_client.init_app()
+    mock_client = MagicMock()
+    mock_client.send_email.return_value = "reference"
     mocker.patch("app.aws_ses_client", mock_client)
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -163,11 +163,11 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         reply_to_address=None,
     )
 
-    # assert "<!DOCTYPE html" in app.aws_ses_client.send_email.call_args[1]["html_body"]
-    # assert (
-    #    "&lt;em&gt;some HTML&lt;/em&gt;"
-    #    in app.aws_ses_client.send_email.call_args[1]["html_body"]
-    # )
+    assert "<!DOCTYPE html" in mock_ses.send_email.call_args[1]["html_body"]
+    assert (
+       "&lt;em&gt;some HTML&lt;/em&gt;"
+       in mock_ses.send_email.call_args[1]["html_body"]
+    )
 
     notification = (
         db.session.execute(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 
 import app
 from app import aws_sns_client, db, notification_provider_clients
+from app.clients.email.aws_ses import AwsSesClient
 from app.cloudfoundry_config import cloud_config
 from app.dao import notifications_dao
 from app.dao.provider_details_dao import get_provider_details_by_identifier
@@ -142,6 +143,11 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         template=sample_email_template_with_html,
     )
     db_notification.personalisation = {"name": "Jo"}
+
+    mock_client = AwsSesClient()
+    mock_client.init_app()
+    mocker.patch("app.aws_ses.client", mock_client)
+
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     send_to_providers.send_email_to_provider(db_notification)
     app.aws_ses_client.send_email.assert_called_once_with(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -146,7 +146,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 
     mock_client = AwsSesClient()
     mock_client.init_app()
-    mocker.patch("app.aws_ses.client", mock_client)
+    mocker.patch("app.aws_ses_client", mock_client)
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     send_to_providers.send_email_to_provider(db_notification)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -149,7 +149,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     mock_ses.send_email.return_value = "reference"
     mock_ses.name = "ses"
     mocker.patch(
-        "app.notification_provider_clients.get_client_by_name_and_type",
+        "app.delivery.send_to_providers.provider_to_use",
         return_value=mock_ses,
     )
 


### PR DESCRIPTION
## Description

Because of the use of gevent and its need for monkey patching, it's necessary that all global variables that use resources be lazily initialized.  This way the monkey patching works for the whole app, and we don't get fork errors under heavy load.

In the PR we do lazy initialization of all the 'easy' global variables, which don't hit too many files.

Note:   This PR is a bit risky.  Even though I ran a bulk send test locally and it was successful, the PR might destabilize staging.  So we should push it to staging on its own and QA test it on its own, and be ready to rollback.

## Security Considerations

N/A